### PR TITLE
Optional constructor rounding

### DIFF
--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -48,8 +48,8 @@ struct AnchoredInterval{P, T} <: AbstractInterval{T}
     anchor::T
     inclusivity::Inclusivity
 
-    function AnchoredInterval{P, T}(anchor::T, inc::Inclusivity) where {P, T}
-        if P isa Period && P != zero(P)
+    function AnchoredInterval{P, T}(anchor::T, inc::Inclusivity; round::Bool=false) where {P, T}
+        if round && P isa Period && P != zero(P)
             anchor = P < zero(P) ? ceil(anchor, abs(P)) : floor(anchor, P)
         end
         return new(anchor, inc)
@@ -58,30 +58,23 @@ end
 
 # When an interval is anchored to the lesser endpoint, default to Inclusivity(false, true)
 # When an interval is anchored to the greater endpoint, default to Inclusivity(true, false)
-function AnchoredInterval{P, T}(i::T) where {P, T}
-    return AnchoredInterval{P, T}(i::T, Inclusivity(P ≥ zero(P), P ≤ zero(P)))
+function AnchoredInterval{P, T}(i::T; kwargs...) where {P, T}
+    return AnchoredInterval{P, T}(i::T, Inclusivity(P ≥ zero(P), P ≤ zero(P)); kwargs...)
 end
 
-AnchoredInterval{P}(i::T, inc::Inclusivity) where {P, T} = AnchoredInterval{P, T}(i, inc)
-AnchoredInterval{P}(i::T) where {P, T} = AnchoredInterval{P, T}(i)
-
-function AnchoredInterval{P, T}(i::T, x::Bool, y::Bool) where {P, T}
-    return AnchoredInterval{P, T}(i, Inclusivity(x, y))
+function AnchoredInterval{P, T}(i::T, x::Bool, y::Bool; kwargs...) where {P, T}
+    return AnchoredInterval{P, T}(i, Inclusivity(x, y); kwargs...)
 end
 
-function AnchoredInterval{P}(i::T, x::Bool, y::Bool) where {P, T}
-    return AnchoredInterval{P, T}(i, Inclusivity(x, y))
+function AnchoredInterval{P}(i::T, args...; kwargs...) where {P, T}
+    AnchoredInterval{P, T}(i, args...; kwargs...)
 end
 
 const HourEnding{T} = AnchoredInterval{Hour(-1), T}
-HourEnding(i::T) where T = HourEnding{T}(i)
-HourEnding(i::T, inc::Inclusivity) where T = HourEnding{T}(i, inc)
-HourEnding(i::T, x::Bool, y::Bool) where T = HourEnding{T}(i, x, y)
+HourEnding(i::T, args...; kwargs...) where T = HourEnding{T}(i, args...; kwargs...)
 
 const HourBeginning{T} = AnchoredInterval{Hour(1), T}
-HourBeginning(i::T) where T = HourBeginning{T}(i)
-HourBeginning(i::T, inc::Inclusivity) where T = HourBeginning{T}(i, inc)
-HourBeginning(i::T, x::Bool, y::Bool) where T = HourBeginning{T}(i, x, y)
+HourBeginning(i::T, args...; kwargs...) where T = HourBeginning{T}(i, args...; kwargs...)
 
 function Base.copy(x::AnchoredInterval{P, T}) where {P, T}
     return AnchoredInterval{P, T}(anchor(x), inclusivity(x))

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -4,23 +4,23 @@
     @testset "constructor" begin
         expected = AnchoredInterval{Hour(-1), DateTime}(dt, Inclusivity(false, true))
         @test AnchoredInterval{Hour(-1), DateTime}(dt) == expected
-        @test AnchoredInterval{Hour(-1), DateTime}(dt - Minute(59)) == expected
+        @test AnchoredInterval{Hour(-1), DateTime}(dt - Minute(59), round=true) == expected
         @test AnchoredInterval{Hour(-1)}(dt) == expected
-        @test AnchoredInterval{Hour(-1)}(dt - Minute(59)) == expected
+        @test AnchoredInterval{Hour(-1)}(dt - Minute(59), round=true) == expected
         @test HourEnding{DateTime}(dt) == expected
-        @test HourEnding{DateTime}(dt - Minute(59)) == expected
+        @test HourEnding{DateTime}(dt - Minute(59), round=true) == expected
         @test HourEnding(dt) == expected
-        @test HourEnding(dt - Minute(59)) == expected
+        @test HourEnding(dt - Minute(59), round=true) == expected
 
         expected = AnchoredInterval{Hour(1), DateTime}(dt, Inclusivity(true, false))
         @test AnchoredInterval{Hour(1), DateTime}(dt) == expected
-        @test AnchoredInterval{Hour(1), DateTime}(dt + Minute(59)) == expected
+        @test AnchoredInterval{Hour(1), DateTime}(dt + Minute(59), round=true) == expected
         @test AnchoredInterval{Hour(1)}(dt) == expected
-        @test AnchoredInterval{Hour(1)}(dt + Minute(59)) == expected
+        @test AnchoredInterval{Hour(1)}(dt + Minute(59), round=true) == expected
         @test HourBeginning{DateTime}(dt) == expected
-        @test HourBeginning{DateTime}(dt + Minute(59)) == expected
+        @test HourBeginning{DateTime}(dt + Minute(59), round=true) == expected
         @test HourBeginning(dt) == expected
-        @test HourBeginning(dt + Minute(59)) == expected
+        @test HourBeginning(dt + Minute(59), round=true) == expected
 
         # Lazy inclusivity constructor
         @test HourEnding{DateTime}(dt, true, false) ==
@@ -57,7 +57,7 @@
 
         inc = Inclusivity(false, false)
         P = Day(1)
-        interval = AnchoredInterval{P}(dt, inc)
+        interval = AnchoredInterval{P}(dt, inc, round=true)
 
         @test first(interval) == DateTime(2016, 8, 11)
         @test last(interval) == DateTime(2016, 8, 12)
@@ -151,13 +151,13 @@
             "Inclusivity(false, true))",
         )
 
-        interval = AnchoredInterval{Year(-1)}(Date(dt))
+        interval = AnchoredInterval{Year(-1)}(Date(dt), round=true)
         @test string(interval) == "(YE2017]"
         @test sprint(showcompact, interval) == string(interval)
         @test sprint(show, interval) ==
             "AnchoredInterval{-1 year, Date}(2017-01-01, Inclusivity(false, true))"
 
-        interval = AnchoredInterval{Month(-1)}(dt)
+        interval = AnchoredInterval{Month(-1)}(dt, round=true)
         @test string(interval) == "(2016 MoE09]"
         @test sprint(showcompact, interval) == string(interval)
         @test sprint(show, interval) == string(
@@ -165,7 +165,7 @@
             "Inclusivity(false, true))",
         )
 
-        interval = AnchoredInterval{Day(-1)}(DateTime(dt))
+        interval = AnchoredInterval{Day(-1)}(DateTime(dt), round=true)
         @test string(interval) == "(2016-08 DE12]"
         @test sprint(showcompact, interval) == string(interval)
         @test sprint(show, interval) ==

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -4,6 +4,7 @@
     @testset "constructor" begin
         expected = AnchoredInterval{Hour(-1), DateTime}(dt, Inclusivity(false, true))
         @test AnchoredInterval{Hour(-1), DateTime}(dt) == expected
+        @test AnchoredInterval{Hour(-1), DateTime}(dt - Minute(59)) == expected - Minute(59)
         @test AnchoredInterval{Hour(-1), DateTime}(dt - Minute(59), round=true) == expected
         @test AnchoredInterval{Hour(-1)}(dt) == expected
         @test AnchoredInterval{Hour(-1)}(dt - Minute(59), round=true) == expected
@@ -14,6 +15,7 @@
 
         expected = AnchoredInterval{Hour(1), DateTime}(dt, Inclusivity(true, false))
         @test AnchoredInterval{Hour(1), DateTime}(dt) == expected
+        @test AnchoredInterval{Hour(1), DateTime}(dt + Minute(59)) == expected + Minute(59)
         @test AnchoredInterval{Hour(1), DateTime}(dt + Minute(59), round=true) == expected
         @test AnchoredInterval{Hour(1)}(dt) == expected
         @test AnchoredInterval{Hour(1)}(dt + Minute(59), round=true) == expected


### PR DESCRIPTION
Only round an `AnchoredInterval` when the keyword `round` is set.