### PR TITLE
Endpoint equality

### DIFF
--- a/src/endpoint.jl
+++ b/src/endpoint.jl
@@ -21,6 +21,26 @@ RightEndpoint(ep::T, included::Bool) where T = RightEndpoint{T}(ep, included)
 LeftEndpoint(i::AbstractInterval{T}) where T = LeftEndpoint{T}(first(i), first(inclusivity(i)))
 RightEndpoint(i::AbstractInterval{T}) where T = RightEndpoint{T}(last(i), last(inclusivity(i)))
 
+
+"""
+    ==(a::LeftEndpoint{T}, b::RightEndpoint{T}) where T -> Bool
+    ==(a::RightEndpoint{T}, b::LeftEndpoint{T}) where T -> Bool
+
+A left-endpoint and a right-endpoint are only equal when they use the same point and are
+both included. Note that left/right endpoints which are both not included are not equal
+as the left-endpoint contains values below that point while the right-endpoint only contains
+values that are above that point.
+
+Visualizing two touching intervals can assist in understanding this logic:
+
+    [x..y][y..z] -> RightEndpoint == LeftEndpoint
+    [x..y)[y..z] -> RightEndpoint != LeftEndpoint
+    [x..y](y..z] -> RightEndpoint != LeftEndpoint
+    [x..y)(y..z] -> RightEndpoint != LeftEndpoint
+"""
+Base.:(==)(a::Endpoint, b::Endpoint)
+
+
 function Base.:(==)(a::LeftEndpoint{T}, b::RightEndpoint{T}) where T
     a.endpoint == b.endpoint && a.included && b.included
 end

--- a/src/endpoint.jl
+++ b/src/endpoint.jl
@@ -21,6 +21,14 @@ RightEndpoint(ep::T, included::Bool) where T = RightEndpoint{T}(ep, included)
 LeftEndpoint(i::AbstractInterval{T}) where T = LeftEndpoint{T}(first(i), first(inclusivity(i)))
 RightEndpoint(i::AbstractInterval{T}) where T = RightEndpoint{T}(last(i), last(inclusivity(i)))
 
+function Base.:(==)(a::LeftEndpoint{T}, b::RightEndpoint{T}) where T
+    a.endpoint == b.endpoint && a.included && b.included
+end
+
+function Base.:(==)(a::RightEndpoint{T}, b::LeftEndpoint{T}) where T
+    a.endpoint == b.endpoint && a.included && b.included
+end
+
 function Base.isless(a::LeftEndpoint{T}, b::LeftEndpoint{T}) where T
     a.endpoint < b.endpoint || (a.endpoint == b.endpoint && a.included && !b.included)
 end

--- a/test/endpoint.jl
+++ b/test/endpoint.jl
@@ -158,4 +158,52 @@ using Intervals: LeftEndpoint, RightEndpoint
         @test !(2 < Endpoint(1, false))
         @test !(2 < Endpoint(1, true))
     end
+
+    @testset "LeftEndpoint == LeftEndpoint" begin
+        @test LeftEndpoint(1, false) != LeftEndpoint(2, false)
+        @test LeftEndpoint(1, true) != LeftEndpoint(2, false)
+        @test LeftEndpoint(1, false) != LeftEndpoint(2, true)
+        @test LeftEndpoint(1, true) != LeftEndpoint(2, true)
+
+        @test LeftEndpoint(1, false) == LeftEndpoint(1, false)
+        @test LeftEndpoint(1, true) != LeftEndpoint(1, false)
+        @test LeftEndpoint(1, false) != LeftEndpoint(1, true)
+        @test LeftEndpoint(1, true) == LeftEndpoint(1, true)
+    end
+
+    @testset "RightEndpoint == RightEndpoint" begin
+        @test RightEndpoint(1, false) != RightEndpoint(2, false)
+        @test RightEndpoint(1, true) != RightEndpoint(2, false)
+        @test RightEndpoint(1, false) != RightEndpoint(2, true)
+        @test RightEndpoint(1, true) != RightEndpoint(2, true)
+
+        @test RightEndpoint(1, false) == RightEndpoint(1, false)
+        @test RightEndpoint(1, true) != RightEndpoint(1, false)
+        @test RightEndpoint(1, false) != RightEndpoint(1, true)
+        @test RightEndpoint(1, true) == RightEndpoint(1, true)
+    end
+
+    @testset "LeftEndpoint == RightEndpoint" begin
+        @test LeftEndpoint(1, false) != RightEndpoint(2, false)
+        @test LeftEndpoint(1, true) != RightEndpoint(2, false)
+        @test LeftEndpoint(1, false) != RightEndpoint(2, true)
+        @test LeftEndpoint(1, true) != RightEndpoint(2, true)
+
+        @test LeftEndpoint(1, false) != RightEndpoint(1, false)
+        @test LeftEndpoint(1, true) != RightEndpoint(1, false)
+        @test LeftEndpoint(1, false) != RightEndpoint(1, true)
+        @test LeftEndpoint(1, true) == RightEndpoint(1, true)
+    end
+
+    @testset "RightEndpoint == LeftEndpoint" begin
+        @test RightEndpoint(1, false) != LeftEndpoint(2, false)
+        @test RightEndpoint(1, true) != LeftEndpoint(2, false)
+        @test RightEndpoint(1, false) != LeftEndpoint(2, true)
+        @test RightEndpoint(1, true) != LeftEndpoint(2, true)
+
+        @test RightEndpoint(1, false) != LeftEndpoint(1, false)
+        @test RightEndpoint(1, true) != LeftEndpoint(1, false)
+        @test RightEndpoint(1, false) != LeftEndpoint(1, true)
+        @test RightEndpoint(1, true) == LeftEndpoint(1, true)
+    end
 end


### PR DESCRIPTION
Verifies that endpoint `==` works. ~I need this~ Used in an upcoming PR.