### PR TITLE
Interval comparison tests

### DIFF
--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -185,7 +185,10 @@ end
 
 # Required for min/max of AnchoredInterval{LaxZonedDateTime} when the anchor is AMB or DNE
 function Base.:<(a::AnchoredInterval{P, T}, b::AnchoredInterval{P, T}) where {P, T}
-    return anchor(a) < anchor(b)
+    return (
+        anchor(a) < anchor(b) ||
+        (anchor(a) == anchor(b) && first(inclusivity(a)) && !first(inclusivity(b)))
+    )
 end
 
 ##### RANGE #####

--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -125,6 +125,31 @@ function Base.convert(::Type{Interval{T}}, interval::AnchoredInterval{P, T}) whe
     return Interval{T}(first(interval), last(interval), inclusivity(interval))
 end
 
+# Conversion methods which currently aren't needed but could prove useful. Commented out
+# since these are untested.
+
+#=
+function Base.convert(::Type{AnchoredInterval{P, T}}, interval::Interval{T}) where {P, T}
+    @assert abs(P) == span(interval)
+    anchor = P < zero(P) ? last(interval) : first(interval)
+    AnchoredInterval{P, T}(last(interval), inclusivity(interval))
+end
+
+function Base.convert(::Type{AnchoredInterval{P}}, interval::Interval{T}) where {P, T}
+    @assert abs(P) == span(interval)
+    anchor = P < zero(P) ? last(interval) : first(interval)
+    AnchoredInterval{P, T}(anchor, inclusivity(interval))
+end
+=#
+
+function Base.convert(::Type{AnchoredInterval{Ending}}, interval::Interval{T}) where {T}
+    AnchoredInterval{-span(interval), T}(last(interval), inclusivity(interval))
+end
+
+function Base.convert(::Type{AnchoredInterval{Beginning}}, interval::Interval{T}) where {T}
+    AnchoredInterval{span(interval), T}(first(interval), inclusivity(interval))
+end
+
 Base.convert(::Type{T}, interval::AnchoredInterval{P, T}) where {P, T} = anchor(interval)
 
 # Date/DateTime attempt to convert to Int64 instead of falling back to convert(T, ...)

--- a/src/endpoint.jl
+++ b/src/endpoint.jl
@@ -1,6 +1,11 @@
 struct Direction{T} end
+
 const Left = Direction{:Left}()
 const Right = Direction{:Right}()
+
+const Beginning = Left
+const Ending = Right
+
 
 struct Endpoint{T, D}
     endpoint::T

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -150,6 +150,10 @@ end
 
 ##### EQUALITY #####
 
+function Base.:(==)(a::AbstractInterval{T}, b::AbstractInterval{T}) where T
+    return LeftEndpoint(a) == LeftEndpoint(b) && RightEndpoint(a) == RightEndpoint(b)
+end
+
 Base.:<(a::AbstractInterval{T}, b::T) where T = LeftEndpoint(a) < b
 Base.:<(a::T, b::AbstractInterval{T}) where T = a < LeftEndpoint(b)
 

--- a/test/comparisons.jl
+++ b/test/comparisons.jl
@@ -31,6 +31,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test earlier < later
         @test !(later < earlier)
 
+        @test earlier ≪ later
+        @test !(later ≪ earlier)
+
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
 
@@ -56,6 +59,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
 
         @test earlier < later
         @test !(later < earlier)
+
+        @test earlier ≪ later
+        @test !(later ≪ earlier)
 
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
@@ -83,6 +89,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test earlier < later
         @test !(later < earlier)
 
+        @test earlier ≪ later
+        @test !(later ≪ earlier)
+
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
 
@@ -108,6 +117,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
 
         @test earlier < later
         @test !(later < earlier)
+
+        @test earlier ≪ later
+        @test !(later ≪ earlier)
 
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
@@ -135,6 +147,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test earlier < later
         @test !(later < earlier)
 
+        @test !(earlier ≪ later)
+        @test !(later ≪ earlier)
+
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
 
@@ -161,6 +176,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test earlier < later
         @test !(later < earlier)
 
+        @test !(earlier ≪ later)
+        @test !(later ≪ earlier)
+
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
 
@@ -181,6 +199,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
 
         @test !(a < b)
         @test !(b < a)
+
+        @test !(a ≪ b)
+        @test !(b ≪ a)
 
         @test issubset(a, b)
         @test issubset(b, a)
@@ -203,6 +224,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test a < b
         @test !(b < a)
 
+        @test !(a ≪ b)
+        @test !(b ≪ a)
+
         @test !issubset(a, b)
         @test issubset(b, a)
 
@@ -223,6 +247,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
 
         @test !(a < b)
         @test !(b < a)
+
+        @test !(a ≪ b)
+        @test !(b ≪ a)
 
         @test !issubset(a, b)
         @test issubset(b, a)
@@ -245,6 +272,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test a < b
         @test !(b < a)
 
+        @test !(a ≪ b)
+        @test !(b ≪ a)
+
         @test !issubset(a, b)
         @test issubset(b, a)
 
@@ -265,6 +295,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
 
         @test !(a < b)
         @test !(b < a)
+
+        @test !(a ≪ b)
+        @test !(b ≪ a)
 
         @test issubset(a, b)
         @test !issubset(b, a)
@@ -287,6 +320,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !(a < b)
         @test b < a
 
+        @test !(a ≪ b)
+        @test !(b ≪ a)
+
         @test issubset(a, b)
         @test !issubset(b, a)
 
@@ -307,6 +343,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
 
         @test !(a < b)
         @test !(b < a)
+
+        @test !(a ≪ b)
+        @test !(b ≪ a)
 
         @test issubset(a, b)
         @test issubset(b, a)
@@ -333,6 +372,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
 
         @test !(smaller < larger)
         @test larger < smaller
+
+        @test !(smaller ≪ larger)
+        @test !(larger ≪ smaller)
 
         @test issubset(smaller, larger)
         @test !issubset(larger, smaller)

--- a/test/comparisons.jl
+++ b/test/comparisons.jl
@@ -1,0 +1,287 @@
+using Intervals: Ending, Beginning
+
+function unique_paired_permutation(v::Vector{T}) where T
+    results = Tuple{T, T}[]
+    for (i, j) in unique(sort([x, y]) for x in eachindex(v), y in eachindex(v))
+        push!(results, (v[i], v[j]))
+    end
+    return results
+end
+
+const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beginning}]
+
+@testset "comparisons: $A vs. $B" for (A, B) in unique_paired_permutation(INTERVAL_TYPES)
+
+    # Compare two intervals which are non-overlapping:
+    # Visualization:
+    #
+    # [12]
+    #     [45]
+    @testset "non-overlapping" begin
+        earlier = convert(A, Interval(1, 2, true, true))
+        later = convert(B, Interval(4, 5, true, true))
+
+        # @test isless(earlier, later)
+        # @test !isless(later, earlier)
+
+        @test earlier < later
+        @test !(later < earlier)
+
+        @test !issubset(earlier, later)
+        @test !issubset(later, earlier)
+
+        @test isempty(intersect(earlier, later))
+        # @test isempty(union(a, b))
+    end
+
+    # Compare two intervals which "touch" but both intervals do not include that point:
+    # Visualization:
+    #
+    # (123)
+    #   (345)
+    @testset "touching open/open" begin
+        earlier = convert(A, Interval(1, 3, false, false))
+        later = convert(B, Interval(3, 5, false, false))
+
+        # @test isless(earlier, later)
+        # @test !isless(later, earlier)
+
+        @test earlier < later
+        @test !(later < earlier)
+
+        @test !issubset(earlier, later)
+        @test !issubset(later, earlier)
+
+        @test isempty(intersect(earlier, later))
+        # @test union(a, b) == Interval(1, 5, false, false)
+    end
+
+    # Compare two intervals which "touch" and the later interval includes that point:
+    # Visualization:
+    #
+    # (123)
+    #   [345]
+    @testset "touching open/closed" begin
+        earlier = convert(A, Interval(1, 3, false, false))
+        later = convert(B, Interval(3, 5, true, true))
+
+        # @test isless(earlier, later)
+        # @test !isless(later, earlier)
+
+        @test earlier < later
+        @test !(later < earlier)
+
+        @test !issubset(earlier, later)
+        @test !issubset(later, earlier)
+
+        @test isempty(intersect(earlier, later))
+        # @test union(a, b) == Interval(1, 5, false, true)
+    end
+
+    # Compare two intervals which "touch" and the earlier interval includes that point:
+    # Visualization:
+    #
+    # [123]
+    #   (345)
+    @testset "touching closed/open" begin
+        earlier = convert(A, Interval(1, 3, true, true))
+        later = convert(B, Interval(3, 5, false, false))
+
+        # @test isless(earlier, later)
+        # @test !isless(later, earlier)
+
+        @test earlier < later
+        @test !(later < earlier)
+
+        @test !issubset(earlier, later)
+        @test !issubset(later, earlier)
+
+        @test isempty(intersect(earlier, later))
+        # @test union(a, b) == Interval(1, 5, true, false)
+    end
+
+    # Compare two intervals which "touch" and both intervals include that point:
+    # Visualization:
+    #
+    # [123]
+    #   [345]
+    @testset "touching closed/closed" begin
+        earlier = convert(A, Interval(1, 3, true, true))
+        later = convert(B, Interval(3, 5, true, true))
+
+        # @test isless(earlier, later)
+        # @test !isless(later, earlier)
+
+        @test earlier < later
+        @test !(later < earlier)
+
+        @test !issubset(earlier, later)
+        @test !issubset(later, earlier)
+
+        @test intersect(earlier, later) == Interval(3, 3, true, true)
+        # @test union(a, b) == Interval(1, 5, true, true)
+    end
+
+    # Compare two intervals which overlap
+    # Visualization:
+    #
+    # [1234]
+    #  [2345]
+    @testset "overlapping" begin
+        earlier = convert(A, Interval(1, 4, true, true))
+        later = convert(B, Interval(2, 5, true, true))
+
+        # @test isless(earlier, later)
+        # @test !isless(later, earlier)
+
+        @test earlier < later
+        @test !(later < earlier)
+
+        @test !issubset(earlier, later)
+        @test !issubset(later, earlier)
+
+        @test intersect(earlier, later) == Interval(2, 4, true, true)
+        # @test union(a, b) == Interval(1, 5, true, true)
+    end
+
+    @testset "equal ()/()" begin
+        a = convert(A, Interval(1, 5, false, false))
+        b = convert(B, Interval(1, 5, false, false))
+
+        # @test !isless(a, b)
+        # @test !isless(a, b)
+
+        @test !(a < b)
+        @test !(b < a)
+
+        @test issubset(a, b)
+        @test issubset(b, a)
+
+        @test intersect(a, b) == Interval(1, 5, false, false)
+        # @test union(a, b) == Interval(1, 5, false, false)
+    end
+
+    @testset "equal [)/()" begin
+        a = convert(A, Interval(1, 5, true, false))
+        b = convert(B, Interval(1, 5, false, false))
+
+        # @test isless(a, b)
+        # @test !isless(b, a)
+
+        @test a < b
+        @test !(b < a)
+
+        @test !issubset(a, b)
+        @test issubset(b, a)
+
+        @test intersect(a, b) == Interval(1, 5, false, false)
+        # @test union(a, b) == Interval(1, 5, true, false)
+    end
+
+    @testset "equal (]/()" begin
+        a = convert(A, Interval(1, 5, false, true))
+        b = convert(B, Interval(1, 5, false, false))
+
+        # @test !isless(a, b)
+        # @test !isless(b, a)
+
+        @test !(a < b)
+        @test !(b < a)
+
+        @test !issubset(a, b)
+        @test issubset(b, a)
+
+        @test intersect(a, b) == Interval(1, 5, false, false)
+        # @test union(a, b) == Interval(1, 5, false, true)
+    end
+
+    @testset "equal []/()" begin
+        a = convert(A, Interval(1, 5, true, true))
+        b = convert(B, Interval(1, 5, false, false))
+
+        # @test isless(a, b)
+        # @test !isless(b, a)
+
+        @test a < b
+        @test !(b < a)
+
+        @test !issubset(a, b)
+        @test issubset(b, a)
+
+        @test intersect(a, b) == Interval(1, 5, false, false)
+        # @test union(a, b) == Interval(1, 5, true, true)
+    end
+
+    @testset "equal [)/[]" begin
+        a = convert(A, Interval(1, 5, true, false))
+        b = convert(B, Interval(1, 5, true, true))
+
+        # @test !isless(a, b)
+        # @test !isless(b, a)
+
+        @test !(a < b)
+        @test !(b < a)
+
+        @test issubset(a, b)
+        @test !issubset(b, a)
+
+        @test intersect(a, b) == Interval(1, 5, true, false)
+        # @test union(a, b) == Interval(1, 5, true, true)
+    end
+
+    @testset "equal (]/[]" begin
+        a = convert(A, Interval(1, 5, false, true))
+        b = convert(B, Interval(1, 5, true, true))
+
+        # @test !isless(a, b)
+        # @test isless(b, a)
+
+        @test !(a < b)
+        @test b < a
+
+        @test issubset(a, b)
+        @test !issubset(b, a)
+
+        @test intersect(a, b) == Interval(1, 5, false, true)
+        # @test union(a, b) == Interval(1, 5, true, true)
+    end
+
+    @testset "equal []/[]" begin
+        a = convert(A, Interval(1, 5, true, true))
+        b = convert(B, Interval(1, 5, true, true))
+
+        # @test !isless(a, b)
+        # @test !isless(b, a)
+
+        @test !(a < b)
+        @test !(b < a)
+
+        @test issubset(a, b)
+        @test issubset(b, a)
+
+        @test intersect(a, b) == Interval(1, 5, true, true)
+        # @test union(a, b) == Interval(1, 5, true, true)
+    end
+
+    # Compare two intervals where the first interval is contained by the second
+    # Visualization:
+    #
+    #  [234]
+    # [12345]
+    @testset "containing" begin
+        smaller = convert(A, Interval(2, 4, true, true))
+        larger = convert(B, Interval(1, 5, true, true))
+
+        # @test !isless(smaller, larger)
+        # @test isless(larger, smaller)
+
+        @test !(smaller < larger)
+        @test larger < smaller
+
+        @test issubset(smaller, larger)
+        @test !issubset(larger, smaller)
+
+        @test intersect(smaller, larger) == Interval(smaller)
+        # @test union(smaller, larger) == Interval(larger)
+    end
+end

--- a/test/comparisons.jl
+++ b/test/comparisons.jl
@@ -21,6 +21,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         earlier = convert(A, Interval(1, 2, true, true))
         later = convert(B, Interval(4, 5, true, true))
 
+        @test earlier != later
+        @test !isequal(earlier, later)
+        @test hash(earlier) != hash(later)
+
         # @test isless(earlier, later)
         # @test !isless(later, earlier)
 
@@ -42,6 +46,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
     @testset "touching open/open" begin
         earlier = convert(A, Interval(1, 3, false, false))
         later = convert(B, Interval(3, 5, false, false))
+
+        @test earlier != later
+        @test !isequal(earlier, later)
+        @test hash(earlier) != hash(later)
 
         # @test isless(earlier, later)
         # @test !isless(later, earlier)
@@ -65,6 +73,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         earlier = convert(A, Interval(1, 3, false, false))
         later = convert(B, Interval(3, 5, true, true))
 
+        @test earlier != later
+        @test !isequal(earlier, later)
+        @test hash(earlier) != hash(later)
+
         # @test isless(earlier, later)
         # @test !isless(later, earlier)
 
@@ -86,6 +98,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
     @testset "touching closed/open" begin
         earlier = convert(A, Interval(1, 3, true, true))
         later = convert(B, Interval(3, 5, false, false))
+
+        @test earlier != later
+        @test !isequal(earlier, later)
+        @test hash(earlier) != hash(later)
 
         # @test isless(earlier, later)
         # @test !isless(later, earlier)
@@ -109,6 +125,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         earlier = convert(A, Interval(1, 3, true, true))
         later = convert(B, Interval(3, 5, true, true))
 
+        @test earlier != later
+        @test !isequal(earlier, later)
+        @test hash(earlier) != hash(later)
+
         # @test isless(earlier, later)
         # @test !isless(later, earlier)
 
@@ -131,6 +151,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         earlier = convert(A, Interval(1, 4, true, true))
         later = convert(B, Interval(2, 5, true, true))
 
+        @test earlier != later
+        @test !isequal(earlier, later)
+        @test hash(earlier) != hash(later)
+
         # @test isless(earlier, later)
         # @test !isless(later, earlier)
 
@@ -147,6 +171,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
     @testset "equal ()/()" begin
         a = convert(A, Interval(1, 5, false, false))
         b = convert(B, Interval(1, 5, false, false))
+
+        @test a == b
+        @test A != B || isequal(a, b)
+        @test A != B || hash(a) == hash(b)
 
         # @test !isless(a, b)
         # @test !isless(a, b)
@@ -165,6 +193,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         a = convert(A, Interval(1, 5, true, false))
         b = convert(B, Interval(1, 5, false, false))
 
+        @test a != b
+        @test !isequal(a, b)
+        @test hash(a) != hash(b)
+
         # @test isless(a, b)
         # @test !isless(b, a)
 
@@ -181,6 +213,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
     @testset "equal (]/()" begin
         a = convert(A, Interval(1, 5, false, true))
         b = convert(B, Interval(1, 5, false, false))
+
+        @test a != b
+        @test !isequal(a, b)
+        @test hash(a) != hash(b)
 
         # @test !isless(a, b)
         # @test !isless(b, a)
@@ -199,6 +235,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         a = convert(A, Interval(1, 5, true, true))
         b = convert(B, Interval(1, 5, false, false))
 
+        @test a != b
+        @test !isequal(a, b)
+        @test hash(a) != hash(b)
+
         # @test isless(a, b)
         # @test !isless(b, a)
 
@@ -215,6 +255,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
     @testset "equal [)/[]" begin
         a = convert(A, Interval(1, 5, true, false))
         b = convert(B, Interval(1, 5, true, true))
+
+        @test a != b
+        @test !isequal(a, b)
+        @test hash(a) != hash(b)
 
         # @test !isless(a, b)
         # @test !isless(b, a)
@@ -233,6 +277,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         a = convert(A, Interval(1, 5, false, true))
         b = convert(B, Interval(1, 5, true, true))
 
+        @test a != b
+        @test !isequal(a, b)
+        @test hash(a) != hash(b)
+
         # @test !isless(a, b)
         # @test isless(b, a)
 
@@ -249,6 +297,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
     @testset "equal []/[]" begin
         a = convert(A, Interval(1, 5, true, true))
         b = convert(B, Interval(1, 5, true, true))
+
+        @test a == b
+        @test A != B || isequal(a, b)
+        @test A != B || hash(a) == hash(b)
 
         # @test !isless(a, b)
         # @test !isless(b, a)
@@ -271,6 +323,10 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
     @testset "containing" begin
         smaller = convert(A, Interval(2, 4, true, true))
         larger = convert(B, Interval(1, 5, true, true))
+
+        @test smaller != larger
+        @test !isequal(smaller, larger)
+        @test hash(smaller) != hash(larger)
 
         # @test !isless(smaller, larger)
         # @test isless(larger, smaller)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,4 +8,5 @@ using Base.Dates
     include("endpoint.jl")
     include("interval.jl")
     include("anchoredinterval.jl")
+    include("comparisons.jl")
 end


### PR DESCRIPTION
A new test suite which performs a variety of comparisons on the various possible kinds of intervals. I found this to be rather useful for catching corner cases as I modified the code.

I've also modified `isless` and `<` to be different. The behaviour of `isless` which is used for sorting just checks the left-endpoint. When the left-endpoints are equal the two intervals are considered equal for sorting and are produced in the order in which they appear. 