### PR TITLE
Replace `in` with `issubset`

### DIFF
--- a/src/Intervals.jl
+++ b/src/Intervals.jl
@@ -6,6 +6,8 @@ using Base.Dates
 using TimeZones
 using Compat: AbstractDateTime
 
+import Base: ⊆, ⊇, ⊈, ⊉
+
 abstract type AbstractInterval{T} end
 
 include("inclusivity.jl")
@@ -30,8 +32,7 @@ export AbstractInterval,
        span,
        less_than_disjoint,
        greater_than_disjoint,
-       ..,
-       ≪,
-       ≫
+       .., ≪, ≫, ⊆, ⊇, ⊈, ⊉
+
 
 end

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -182,6 +182,7 @@ true
 ```
 """
 ≪(a, b) = less_than_disjoint(a, b)
+# ≪̸(a, b) = !≪(a, b)
 
 """
     ≫(a::AbstractInterval, b::AbstractInterval) -> Bool
@@ -199,15 +200,19 @@ true
 ```
 """
 ≫(a, b) = greater_than_disjoint(a, b)
+# ≫̸(a, b) = !≫(a, b)
 
 ##### SET OPERATIONS #####
 
 Base.isempty(i::AbstractInterval) = LeftEndpoint(i) > RightEndpoint(i)
 Base.in(a::T, b::AbstractInterval{T}) where T = !(a ≫ b || a ≪ b)
 
-function Base.in(a::AbstractInterval{T}, b::AbstractInterval{T}) where T
+function Base.issubset(a::AbstractInterval{T}, b::AbstractInterval{T}) where T
     return LeftEndpoint(a) ≥ LeftEndpoint(b) && RightEndpoint(a) ≤ RightEndpoint(b)
 end
+
+Base.:⊈(a::AbstractInterval{T}, b::AbstractInterval{T}) where T = !issubset(a, b)
+Base.:⊉(a::AbstractInterval{T}, b::AbstractInterval{T}) where T = !issubset(b, a)
 
 # Should probably define union, too. There is power in a union.
 

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -322,15 +322,25 @@
             @test in(b - unit, interval)
             @test !in(b + unit, interval)
         end
+    end
 
-        @test in(0..10, 0..10)
-        @test in(Interval(0, 10, false, false), 0..10)
-        @test !in(0..10, Interval(0, 10, false, false))
-        @test in(1..9, 0..10)
-        @test !in(0..10, 1..9)
-        @test !in(1..11, 0..10)
-        @test !in(-1..9, 0..10)
-        @test !in(20..30, 0..10)
+    @testset "issubset" begin
+        @test 0..10 ⊆ 0..10
+        @test 0..10 ⊇ 0..10
+        @test Interval(0, 10, false, false) ⊆ 0..10
+        @test Interval(0, 10, false, false) ⊉ 0..10
+        @test 0..10 ⊈ Interval(0, 10, false, false)
+        @test 0..10 ⊇ Interval(0, 10, false, false)
+        @test 1..9 ⊆ 0..10
+        @test 1..9 ⊉ 0..10
+        @test 0..10 ⊈ 1..9
+        @test 0..10 ⊇ 1..9
+        @test 1..11 ⊈ 0..10
+        @test 1..11 ⊉ 0..10
+        @test -1..9 ⊈ 0..10
+        @test -1..9 ⊉ 0..10
+        @test 20..30 ⊈ 0..10
+        @test 20..30 ⊉ 0..10
     end
 
     @testset "intersect" begin


### PR DESCRIPTION
Replace `in(::AbstractInterval, ::AbstractInterval)` with `issubset(::AbstractInterval, ::AbstractInterval)` and define/export `⊆`, `⊇`, `⊈`, and `⊉`

Closes #15