### PR TITLE
Add astimezone(::Interval{ZonedDateTime}, ::TimeZone)

### DIFF
--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -1,3 +1,4 @@
+import TimeZones: astimezone
 using Base.Dates: value, coarserperiod
 
 """
@@ -264,3 +265,9 @@ function canonicalize(target_type::Type{<:Period}, p::P) where P <: Period
 end
 
 canonicalize(target_type::Type{P}, p::P) where P <: Period = p
+
+##### TIME ZONES #####
+
+function astimezone(i::AnchoredInterval{P, ZonedDateTime}, tz::TimeZone) where P
+    return AnchoredInterval{P, ZonedDateTime}(astimezone(anchor(i), tz), inclusivity(i))
+end

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -1,3 +1,5 @@
+import TimeZones: astimezone
+
 """
     Interval(first, last, [inclusivity::Inclusivity]) -> Interval
     Interval(first, last, [closed_left::Bool, closed_right::Bool]) -> Interval
@@ -225,4 +227,10 @@ function Base.intersect(a::AbstractInterval{T}, b::AbstractInterval{T}) where T
     right = min(RightEndpoint(a), RightEndpoint(b))
     left > right && return Interval{T}()
     return Interval{T}(left.endpoint, right.endpoint, left.included, right.included)
+end
+
+##### TIME ZONES #####
+
+function astimezone(i::Interval{ZonedDateTime}, tz::TimeZone)
+    return Interval(astimezone(first(i), tz), astimezone(last(i), tz), inclusivity(i))
 end

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -513,4 +513,22 @@ using Intervals: canonicalize
         @test canonicalize(Year, Millisecond(2419200000)) == Week(4)
         @test canonicalize(Year, Millisecond(4233600000)) == Week(7)
     end
+
+    @testset "astimezone" begin
+        zdt = ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg")
+
+        for inclusivity in Inclusivity.(0:3)
+            for tz in (tz"America/Winnipeg", tz"America/Regina", tz"UTC")
+                @test isequal(
+                    astimezone(HE(zdt, inclusivity), tz),
+                    HE(astimezone(zdt, tz), inclusivity),
+                )
+
+                @test isequal(
+                    astimezone(AnchoredInterval{Day(1)}(zdt, inclusivity), tz),
+                    AnchoredInterval{Day(1)}(astimezone(zdt, tz), inclusivity),
+                )
+            end
+        end
+    end
 end

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -419,4 +419,18 @@
             end
         end
     end
+
+    @testset "astimezone" begin
+        zdt1 = ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg")
+        zdt2 = ZonedDateTime(2016, 8, 11, 21, tz"America/Winnipeg")
+
+        for inclusivity in Inclusivity.(0:3)
+            for tz in (tz"America/Winnipeg", tz"America/Regina", tz"UTC")
+                @test isequal(
+                    astimezone(Interval(zdt1, zdt2, inclusivity), tz),
+                    Interval(astimezone(zdt1, tz), astimezone(zdt2, tz), inclusivity),
+                )
+            end
+        end
+    end
 end


### PR DESCRIPTION
Allows us to easily convert `Interval`s and `AnchoredInterval`s from one time zone to another.