### PR TITLE
Replace `<` with `isless`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -128,8 +128,9 @@ julia> ZonedDateTime(he)
 When determining whether one `AbstractInterval` is less than (or greater than) another, two
 sets of comparison operators are available: `<`/`>` and `≪`/`≫`.
 
-The standard `<` and `>` operators simply compare the leftmost endpoint of the intervals,
-and are used for things like `sort`, `min`, `max`, etc.
+The standard `<` and `>` operators (which are not explicitly defined, but are derived from
+`isless`) simply compare the leftmost endpoint of the intervals, and are used for things
+like `sort`, `min`, `max`, etc.
 
 The `≪` and `≫` operators (the Unicode symbols for "much less than" and "much greater than",
 accessible from the REPL with `\ll` and `\gg`, respectively) are used in this context to

--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -210,7 +210,7 @@ end
 ##### EQUALITY #####
 
 # Required for min/max of AnchoredInterval{LaxZonedDateTime} when the anchor is AMB or DNE
-function Base.:<(a::AnchoredInterval{P, T}, b::AnchoredInterval{P, T}) where {P, T}
+function Base.isless(a::AnchoredInterval{P, T}, b::AnchoredInterval{P, T}) where {P, T}
     return (
         anchor(a) < anchor(b) ||
         (anchor(a) == anchor(b) && first(inclusivity(a)) && !first(inclusivity(b)))

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -156,13 +156,15 @@ function Base.:(==)(a::AbstractInterval{T}, b::AbstractInterval{T}) where T
     return LeftEndpoint(a) == LeftEndpoint(b) && RightEndpoint(a) == RightEndpoint(b)
 end
 
-Base.:<(a::AbstractInterval{T}, b::T) where T = LeftEndpoint(a) < b
-Base.:<(a::T, b::AbstractInterval{T}) where T = a < LeftEndpoint(b)
+# While it might be convincingly argued that this should define < instead of isless (see
+# https://github.com/invenia/Intervals.jl/issues/14), this breaks sort.
+Base.isless(a::AbstractInterval{T}, b::T) where T = LeftEndpoint(a) < b
+Base.isless(a::T, b::AbstractInterval{T}) where T = a < LeftEndpoint(b)
 
 less_than_disjoint(a::AbstractInterval{T}, b::T) where T = RightEndpoint(a) < b
 less_than_disjoint(a::T, b::AbstractInterval{T}) where T = a < LeftEndpoint(b)
 
-function Base.:<(a::AbstractInterval{T}, b::AbstractInterval{T}) where T
+function Base.:isless(a::AbstractInterval{T}, b::AbstractInterval{T}) where T
     return LeftEndpoint(a) < LeftEndpoint(b)
 end
 

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -301,6 +301,8 @@ using Intervals: canonicalize
         @test hash(he) != hash(diff_inc)
 
         # Overlap for an instant, so not disjoint
+        @test isless(he, hb)
+        @test !isless(hb, he)
         @test he < hb
         @test !(hb < he)
         @test !(he > hb)
@@ -313,9 +315,11 @@ using Intervals: canonicalize
         @test he ≪ he + Hour(1)
         @test hb ≪ hb + Hour(1)
 
+        @test isless(diff_inc, diff_inc + Hour(2))
+        @test isless(diff_inc, diff_inc + Hour(1))
         @test diff_inc < diff_inc + Hour(2)
-        @test diff_inc ≪ diff_inc + Hour(2)
         @test diff_inc < diff_inc + Hour(1)
+        @test diff_inc ≪ diff_inc + Hour(2)
         @test !(diff_inc ≪ diff_inc + Hour(1))  # Overlap for an instant
 
         # DST transition
@@ -344,6 +348,16 @@ using Intervals: canonicalize
         @test HourEnding(dt, Inclusivity(true, true)) < dt
         @test !(HourEnding(dt, Inclusivity(true, true)) ≪ dt)
         @test HourEnding(dt) < dt + Hour(1)
+    end
+
+    @testset "sort" begin
+        hb1 = HourBeginning(dt)
+        he1 = HourEnding(dt)
+        he2 = HourEnding(dt + Hour(1))
+        he3 = HourEnding(dt + Hour(2))
+
+        @test sort([hb1, he1, he2, he3]) == [he1, hb1, he2, he3]
+        @test sort([hb1, he1, he2, he3]; rev=true) == [he3, he2, hb1, he1]
     end
 
     @testset "arithmetic" begin

--- a/test/comparisons.jl
+++ b/test/comparisons.jl
@@ -25,8 +25,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
 
-        # @test isless(earlier, later)
-        # @test !isless(later, earlier)
+        @test isless(earlier, later)
+        @test !isless(later, earlier)
 
         @test earlier < later
         @test !(later < earlier)
@@ -54,8 +54,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
 
-        # @test isless(earlier, later)
-        # @test !isless(later, earlier)
+        @test isless(earlier, later)
+        @test !isless(later, earlier)
 
         @test earlier < later
         @test !(later < earlier)
@@ -83,8 +83,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
 
-        # @test isless(earlier, later)
-        # @test !isless(later, earlier)
+        @test isless(earlier, later)
+        @test !isless(later, earlier)
 
         @test earlier < later
         @test !(later < earlier)
@@ -112,8 +112,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
 
-        # @test isless(earlier, later)
-        # @test !isless(later, earlier)
+        @test isless(earlier, later)
+        @test !isless(later, earlier)
 
         @test earlier < later
         @test !(later < earlier)
@@ -141,8 +141,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
 
-        # @test isless(earlier, later)
-        # @test !isless(later, earlier)
+        @test isless(earlier, later)
+        @test !isless(later, earlier)
 
         @test earlier < later
         @test !(later < earlier)
@@ -170,8 +170,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
 
-        # @test isless(earlier, later)
-        # @test !isless(later, earlier)
+        @test isless(earlier, later)
+        @test !isless(later, earlier)
 
         @test earlier < later
         @test !(later < earlier)
@@ -194,8 +194,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test A != B || isequal(a, b)
         @test A != B || hash(a) == hash(b)
 
-        # @test !isless(a, b)
-        # @test !isless(a, b)
+        @test !isless(a, b)
+        @test !isless(a, b)
 
         @test !(a < b)
         @test !(b < a)
@@ -218,8 +218,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(a, b)
         @test hash(a) != hash(b)
 
-        # @test isless(a, b)
-        # @test !isless(b, a)
+        @test isless(a, b)
+        @test !isless(b, a)
 
         @test a < b
         @test !(b < a)
@@ -242,8 +242,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(a, b)
         @test hash(a) != hash(b)
 
-        # @test !isless(a, b)
-        # @test !isless(b, a)
+        @test !isless(a, b)
+        @test !isless(b, a)
 
         @test !(a < b)
         @test !(b < a)
@@ -266,8 +266,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(a, b)
         @test hash(a) != hash(b)
 
-        # @test isless(a, b)
-        # @test !isless(b, a)
+        @test isless(a, b)
+        @test !isless(b, a)
 
         @test a < b
         @test !(b < a)
@@ -290,8 +290,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(a, b)
         @test hash(a) != hash(b)
 
-        # @test !isless(a, b)
-        # @test !isless(b, a)
+        @test !isless(a, b)
+        @test !isless(b, a)
 
         @test !(a < b)
         @test !(b < a)
@@ -314,8 +314,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(a, b)
         @test hash(a) != hash(b)
 
-        # @test !isless(a, b)
-        # @test isless(b, a)
+        @test !isless(a, b)
+        @test isless(b, a)
 
         @test !(a < b)
         @test b < a
@@ -338,8 +338,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test A != B || isequal(a, b)
         @test A != B || hash(a) == hash(b)
 
-        # @test !isless(a, b)
-        # @test !isless(b, a)
+        @test !isless(a, b)
+        @test !isless(b, a)
 
         @test !(a < b)
         @test !(b < a)
@@ -367,8 +367,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !isequal(smaller, larger)
         @test hash(smaller) != hash(larger)
 
-        # @test !isless(smaller, larger)
-        # @test isless(larger, smaller)
+        @test !isless(smaller, larger)
+        @test isless(larger, smaller)
 
         @test !(smaller < larger)
         @test larger < smaller

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -122,22 +122,27 @@
                 @test hash(interval) != hash(lesser_val)
                 @test hash(interval) != hash(diff_inc)
 
+                @test !isless(interval, cp)
                 @test !(interval < cp)
                 @test !(interval ≪ cp)
                 @test !(interval > cp)
                 @test !(interval ≫ cp)
+                @test isless(interval, greater_val)
                 @test interval < greater_val
                 @test !(interval ≪ greater_val)     # Still overlap, so not disjoint
                 @test !(interval > greater_val)
                 @test !(interval ≫ greater_val)
+                @test !isless(greater_val, interval)
                 @test !(greater_val < interval)
                 @test !(greater_val ≪ interval)     # Still overlap, so not disjoint
                 @test greater_val > interval
                 @test !(greater_val ≫ interval)     # Still overlap, so not disjoint
+                @test isless(lesser_val, interval)
                 @test lesser_val < interval
                 @test !(lesser_val ≪ interval)
                 @test !(lesser_val > interval)
                 @test !(lesser_val ≫ interval)
+                @test !isless(interval, lesser_val)
                 @test !(interval < lesser_val)
                 @test !(interval ≪ lesser_val)
                 @test interval > lesser_val
@@ -162,72 +167,104 @@
         )
 
         # Comparisons between Interval{T} and T
+        @test isless(5, Interval(10, 20))
         @test 5 < Interval(10, 20)
         @test 5 ≪ Interval(10, 20)
         @test !(5 > Interval(10, 20))
         @test !(5 ≫ Interval(10, 20))
 
+        @test isless(10, Interval(10, 20, Inclusivity(false, false)))
         @test 10 < Interval(10, 20, Inclusivity(false, false))
         @test 10 ≪ Interval(10, 20, Inclusivity(false, false))
         @test !(10 > Interval(10, 20, Inclusivity(false, false)))
         @test !(10 ≫ Interval(10, 20, Inclusivity(false, false)))
 
+        @test !isless(10, Interval(10, 20))
         @test !(10 < Interval(10, 20))
         @test !(10 ≪ Interval(10, 20))
         @test !(10 > Interval(10, 20))
         @test !(10 ≫ Interval(10, 20))
 
+        @test !isless(15, Interval(10, 20))
         @test !(15 < Interval(10, 20))
         @test !(15 ≪ Interval(10, 20))
         @test 15 > Interval(10, 20)
         @test !(15 ≫ Interval(10, 20))
 
+        @test !isless(20, Interval(10, 20))
         @test !(20 < Interval(10, 20))
         @test !(20 ≪ Interval(10, 20))
         @test 20 > Interval(10, 20)
         @test !(20 ≫ Interval(10, 20))
 
+        @test !isless(20, Interval(10, 20, Inclusivity(false, false)))
         @test !(20 < Interval(10, 20, Inclusivity(false, false)))
         @test !(20 ≪ Interval(10, 20, Inclusivity(false, false)))
         @test 20 > Interval(10, 20, Inclusivity(false, false))
         @test 20 ≫ Interval(10, 20, Inclusivity(false, false))
 
+        @test !isless(25, Interval(10, 20))
         @test !(25 < Interval(10, 20))
         @test !(25 ≪ Interval(10, 20))
         @test 25 > Interval(10, 20)
         @test 25 ≫ Interval(10, 20)
 
+        @test !isless(Interval(10, 20), 5)
         @test !(Interval(10, 20) < 5)
+        @test !isless(Interval(10, 20, Inclusivity(false, false)), 10)
         @test !(Interval(10, 20, Inclusivity(false, false)) < 10)
+        @test !isless(Interval(10, 20), 10)
         @test !(Interval(10, 20) < 10)
         @test !(Interval(10, 20) ≪ 10)
+        @test isless(Interval(10, 20), 15)
         @test Interval(10, 20) < 15
         @test !(Interval(10, 20) ≪ 15)
+        @test isless(Interval(10, 20), 20)
         @test Interval(10, 20) < 20
         @test !(Interval(10, 20) ≪ 20)
+        @test isless(Interval(10, 20, Inclusivity(false, false)), 20)
         @test Interval(10, 20, Inclusivity(false, false)) < 20
+        @test isless(Interval(10, 20), 25)
         @test Interval(10, 20) < 25
 
-        @test Date(2013) < Interval(Date(2014), Date(2016))
-        @test Date(2014) < Interval(Date(2014), Date(2016), false, false)
-        @test !(Date(2014) < Interval(Date(2014), Date(2016)))
-        @test !(Date(2014) < Interval(Date(2014), Date(2016)))
-        @test !(Date(2015) < Interval(Date(2014), Date(2016)))
-        @test !(Date(2016) < Interval(Date(2014), Date(2016)))
-        @test !(Date(2016) < Interval(Date(2014), Date(2016), false, false))
-        @test !(Date(2017) < Interval(Date(2014), Date(2016)))
+        for lt in (isless, <)
+            @test lt(Date(2013), Interval(Date(2014), Date(2016)))
+            @test lt(Date(2014), Interval(Date(2014), Date(2016), false, false))
+            @test !lt(Date(2014), Interval(Date(2014), Date(2016)))
+            @test !lt(Date(2014), Interval(Date(2014), Date(2016)))
+            @test !lt(Date(2015), Interval(Date(2014), Date(2016)))
+            @test !lt(Date(2016), Interval(Date(2014), Date(2016)))
+            @test !lt(Date(2016), Interval(Date(2014), Date(2016), false, false))
+            @test !lt(Date(2017), Interval(Date(2014), Date(2016)))
+        end
 
+        @test !isless(Interval(Date(2014), Date(2016)), Date(2013))
         @test !(Interval(Date(2014), Date(2016)) < Date(2013))
+        @test !isless(Interval(Date(2014), Date(2016), false, false), Date(2014))
         @test !(Interval(Date(2014), Date(2016), false, false) < Date(2014))
+        @test !isless(Interval(Date(2014), Date(2016)), Date(2014))
         @test !(Interval(Date(2014), Date(2016)) < Date(2014))
         @test !(Interval(Date(2014), Date(2016)) ≪ Date(2014))
+        @test isless(Interval(Date(2014), Date(2016)), Date(2015))
         @test Interval(Date(2014), Date(2016)) < Date(2015)
         @test !(Interval(Date(2014), Date(2016)) ≪ Date(2015))
+        @test isless(Interval(Date(2014), Date(2016)), Date(2016))
         @test Interval(Date(2014), Date(2016)) < Date(2016)
         @test !(Interval(Date(2014), Date(2016)) ≪ Date(2016))
+        @test isless(Interval(Date(2014), Date(2016), false, false), Date(2016))
         @test Interval(Date(2014), Date(2016), false, false) < Date(2016)
         @test Interval(Date(2014), Date(2016), false, false) ≪ Date(2016)
+        @test isless(Interval(Date(2014), Date(2016)), Date(2017))
         @test Interval(Date(2014), Date(2016)) < Date(2017)
+    end
+
+    @testset "sort" begin
+        i1 = 1 .. 10
+        i2 = Interval(1, 10, false, false)
+        i3 = 2 .. 11
+
+        @test sort([i1, i2, i3]) == [i1, i2, i3]
+        @test sort([i1, i2, i3]; rev=true) == [i3, i2, i1]
     end
 
     @testset "arithmetic" begin


### PR DESCRIPTION
Allows `sort`ing of `AbstractInterval`s.

Closes #19