### PR TITLE
Add equality for matching left/right endpoints

### DIFF
--- a/src/endpoint.jl
+++ b/src/endpoint.jl
@@ -43,8 +43,9 @@ Visualizing two touching intervals can assist in understanding this logic:
     [x..y](y..z] -> RightEndpoint != LeftEndpoint
     [x..y)(y..z] -> RightEndpoint != LeftEndpoint
 """
-Base.:(==)(a::Endpoint, b::Endpoint)
-
+function Base.:(==)(a::Endpoint, b::Endpoint)
+    a.endpoint == b.endpoint && a.included == b.included
+end
 
 function Base.:(==)(a::LeftEndpoint{T}, b::RightEndpoint{T}) where T
     a.endpoint == b.endpoint && a.included && b.included


### PR DESCRIPTION
In cases where we have `==(LeftEndpoint, LeftEndpoint)` or `==(RightEndpoint, RightEndpoint)` julia was falling back to the `===` check. This passes tests, but causes problems if the addresses are different. This PR simply adds a default `==(Endpoint, Endpoint)` fallback that just checks if the `endpoint` and `included` variables are equal.