### PR TITLE
Slightly improve Interval inner constructor speed

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -41,7 +41,7 @@ Interval{Date}(2018-01-24, 2018-01-31, Inclusivity(true, true))
 
 ### Note on Ordering
 
-The `Interval` constructor will compare `first` and `last`; if it findes that
+The `Interval` constructor will compare `first` and `last`; if it finds that
 `first > last`, they will be reversed to ensure that `first < last`. This simplifies
 calls to `in` and `intersect`:
 
@@ -60,11 +60,14 @@ struct Interval{T} <: AbstractInterval{T}
     inclusivity::Inclusivity
 
     function Interval{T}(f::T, l::T, inc::Inclusivity) where T
-        return new(
-            f ≤ l ? f : l,
-            l ≥ f ? l : f,
-            f ≤ l ? inc : Inclusivity(last(inc), first(inc)),
-        )
+        # Ensure that `first` preceeds `last`.
+        f, l, inc = if f ≤ l
+            f, l, inc
+        else
+            l, f, Inclusivity(last(inc), first(inc))
+        end
+
+        return new(f, l, inc)
     end
 end
 


### PR DESCRIPTION
While investigating https://github.com/invenia/Intervals.jl/issues/29 I found a way to slightly improve performance of the inner constructor:

```julia
julia> using Intervals, BenchmarkTools

julia> struct IntervalNoCheck{T} <: AbstractInterval{T}
           first::T
           last::T
           inclusivity::Inclusivity

           function IntervalNoCheck{T}(f::T, l::T, inc::Inclusivity) where T
               return new(f, l, inc)
           end
       end

julia> struct IntervalA{T} <: AbstractInterval{T}
           first::T
           last::T
           inclusivity::Inclusivity

           function IntervalA{T}(f::T, l::T, inc::Inclusivity) where T
               if f > l
                   f, l = l, f
                   inc = Inclusivity(last(inc), first(inc))
               end

               return new(f, l, inc)
           end
       end

julia> struct IntervalB{T} <: AbstractInterval{T}
           first::T
           last::T
           inclusivity::Inclusivity

           function IntervalB{T}(f::T, l::T, inc::Inclusivity) where T
               a, b, c = if f ≤ l
                   f, l, inc
               else
                   l, f, Inclusivity(last(inc), first(inc))
               end

               return new(a, b, c)
           end
       end

julia> struct IntervalC{T} <: AbstractInterval{T}
           first::T
           last::T
           inclusivity::Inclusivity

           function IntervalC{T}(f::T, l::T, inc::Inclusivity) where T
               f, l, inc = if f ≤ l
                   f, l, inc
               else
                   l, f, Inclusivity(last(inc), first(inc))
               end

               return new(f, l, inc)
           end
       end

julia> inc = Inclusivity(true,true)
Inclusivity(true, true)

julia>

julia> @btime Interval{Int}(1,2,$(inc))
  7.280 ns (0 allocations: 0 bytes)
Interval{Int64}(1, 2, Inclusivity(true, true))

julia> @btime IntervalNoCheck{Int}(1,2,$(inc))
  1.421 ns (0 allocations: 0 bytes)
IntervalNoCheck{Int64}(1, 2, Inclusivity(true, true))

julia> @btime IntervalA{Int}(1,2,$(inc))
  7.532 ns (0 allocations: 0 bytes)
IntervalA{Int64}(1, 2, Inclusivity(true, true))

julia> @btime IntervalB{Int}(1,2,$(inc))
  7.281 ns (0 allocations: 0 bytes)
IntervalB{Int64}(1, 2, Inclusivity(true, true))

julia> @btime IntervalC{Int}(1,2,$(inc))
  7.280 ns (0 allocations: 0 bytes)
IntervalC{Int64}(1, 2, Inclusivity(true, true))

julia>

julia> @btime Interval{Int}(2,1,$(inc))
  10.786 ns (0 allocations: 0 bytes)
Interval{Int64}(1, 2, Inclusivity(true, true))

julia> @btime IntervalNoCheck{Int}(2,1,$(inc))
  1.347 ns (0 allocations: 0 bytes)
IntervalNoCheck{Int64}(2, 1, Inclusivity(true, true))

julia> @btime IntervalA{Int}(2,1,$(inc))
  8.031 ns (0 allocations: 0 bytes)
IntervalA{Int64}(1, 2, Inclusivity(true, true))

julia> @btime IntervalB{Int}(2,1,$(inc))
  7.782 ns (0 allocations: 0 bytes)
IntervalB{Int64}(1, 2, Inclusivity(true, true))

julia> @btime IntervalC{Int}(2,1,$(inc))
  7.281 ns (0 allocations: 0 bytes)
IntervalC{Int64}(1, 2, Inclusivity(true, true))
```
Originally I used the implementation of `IntervalA` but I noticed that there was a very minor performance decrease over the original implementation with the parameters were ordered. After some experimentation I came up with B and C. The `IntervalC` implementation is as fast as the original implementation for ordered input and for unordered input there is almost no penalty and is 3ns faster than the original.