### PR TITLE
Remove where from Endpoint comparisons

### DIFF
--- a/src/endpoint.jl
+++ b/src/endpoint.jl
@@ -28,15 +28,18 @@ RightEndpoint(i::AbstractInterval{T}) where T = RightEndpoint{T}(last(i), last(i
 
 
 """
-    ==(a::LeftEndpoint{T}, b::RightEndpoint{T}) where T -> Bool
-    ==(a::RightEndpoint{T}, b::LeftEndpoint{T}) where T -> Bool
+    ==(a::Endpoint, b::Endpoint) -> Bool
 
-A left-endpoint and a right-endpoint are only equal when they use the same point and are
+Determine if two endpoints are equal. When both endpoints are left or right then the points
+and inclusiveness must be the same.
+
+Checking the equality of left-endpoint and a right-endpoint is slightly more difficult. A
+left-endpoint and a right-endpoint are only equal when they use the same point and are
 both included. Note that left/right endpoints which are both not included are not equal
 as the left-endpoint contains values below that point while the right-endpoint only contains
 values that are above that point.
 
-Visualizing two touching intervals can assist in understanding this logic:
+Visualizing two contiguous intervals can assist in understanding this logic:
 
     [x..y][y..z] -> RightEndpoint == LeftEndpoint
     [x..y)[y..z] -> RightEndpoint != LeftEndpoint
@@ -47,42 +50,42 @@ function Base.:(==)(a::Endpoint, b::Endpoint)
     a.endpoint == b.endpoint && a.included == b.included
 end
 
-function Base.:(==)(a::LeftEndpoint{T}, b::RightEndpoint{T}) where T
+function Base.:(==)(a::LeftEndpoint, b::RightEndpoint)
     a.endpoint == b.endpoint && a.included && b.included
 end
 
-function Base.:(==)(a::RightEndpoint{T}, b::LeftEndpoint{T}) where T
+function Base.:(==)(a::RightEndpoint, b::LeftEndpoint)
     a.endpoint == b.endpoint && a.included && b.included
 end
 
-function Base.isless(a::LeftEndpoint{T}, b::LeftEndpoint{T}) where T
+function Base.isless(a::LeftEndpoint, b::LeftEndpoint)
     a.endpoint < b.endpoint || (a.endpoint == b.endpoint && a.included && !b.included)
 end
 
-function Base.isless(a::RightEndpoint{T}, b::RightEndpoint{T}) where T
+function Base.isless(a::RightEndpoint, b::RightEndpoint)
     a.endpoint < b.endpoint || (a.endpoint == b.endpoint && !a.included && b.included)
 end
 
-function Base.isless(a::RightEndpoint{T}, b::LeftEndpoint{T}) where T
+function Base.isless(a::RightEndpoint, b::LeftEndpoint)
     a.endpoint < b.endpoint || (a.endpoint == b.endpoint && !(a.included && b.included))
 end
 
-function Base.isless(a::LeftEndpoint{T}, b::RightEndpoint{T}) where T
+function Base.isless(a::LeftEndpoint, b::RightEndpoint)
     a.endpoint < b.endpoint
 end
 
-function Base.isless(a::T, b::LeftEndpoint{T}) where T
+function Base.isless(a, b::LeftEndpoint)
     a < b.endpoint || (a == b.endpoint && !b.included)
 end
 
-function Base.isless(a::T, b::RightEndpoint{T}) where T
+function Base.isless(a, b::RightEndpoint)
     a < b.endpoint
 end
 
-function Base.isless(a::LeftEndpoint{T}, b::T) where T
+function Base.isless(a::LeftEndpoint, b)
     a.endpoint < b
 end
 
-function Base.isless(a::RightEndpoint{T}, b::T) where T
+function Base.isless(a::RightEndpoint, b)
     a.endpoint < b || (a.endpoint == b && !a.included)
 end

--- a/test/endpoint.jl
+++ b/test/endpoint.jl
@@ -2,208 +2,208 @@ using Intervals: LeftEndpoint, RightEndpoint
 
 @testset "Endpoint" begin
     @testset "LeftEndpoint < LeftEndpoint" begin
-        @test LeftEndpoint(1, false) < LeftEndpoint(2, false)
-        @test LeftEndpoint(1, true) < LeftEndpoint(2, false)
-        @test LeftEndpoint(1, false) < LeftEndpoint(2, true)
-        @test LeftEndpoint(1, true) < LeftEndpoint(2, true)
+        @test LeftEndpoint(1, false) < LeftEndpoint(2.0, false)
+        @test LeftEndpoint(1, true) < LeftEndpoint(2.0, false)
+        @test LeftEndpoint(1, false) < LeftEndpoint(2.0, true)
+        @test LeftEndpoint(1, true) < LeftEndpoint(2.0, true)
 
-        @test !(LeftEndpoint(1, false) < LeftEndpoint(1, false))
-        @test LeftEndpoint(1, true) < LeftEndpoint(1, false)
-        @test !(LeftEndpoint(1, false) < LeftEndpoint(1, true))
-        @test !(LeftEndpoint(1, true) < LeftEndpoint(1, true))
+        @test !(LeftEndpoint(1, false) < LeftEndpoint(1.0, false))
+        @test LeftEndpoint(1, true) < LeftEndpoint(1.0, false)
+        @test !(LeftEndpoint(1, false) < LeftEndpoint(1.0, true))
+        @test !(LeftEndpoint(1, true) < LeftEndpoint(1.0, true))
 
-        @test !(LeftEndpoint(2, false) < LeftEndpoint(1, false))
-        @test !(LeftEndpoint(2, true) < LeftEndpoint(1, false))
-        @test !(LeftEndpoint(2, false) < LeftEndpoint(1, true))
-        @test !(LeftEndpoint(2, true) < LeftEndpoint(1, true))
+        @test !(LeftEndpoint(2, false) < LeftEndpoint(1.0, false))
+        @test !(LeftEndpoint(2, true) < LeftEndpoint(1.0, false))
+        @test !(LeftEndpoint(2, false) < LeftEndpoint(1.0, true))
+        @test !(LeftEndpoint(2, true) < LeftEndpoint(1.0, true))
     end
 
     @testset "LeftEndpoint <= LeftEndpoint" begin
-        @test LeftEndpoint(1, false) <= LeftEndpoint(2, false)
-        @test LeftEndpoint(1, true) <= LeftEndpoint(2, false)
-        @test LeftEndpoint(1, false) <= LeftEndpoint(2, true)
-        @test LeftEndpoint(1, true) <= LeftEndpoint(2, true)
+        @test LeftEndpoint(1, false) <= LeftEndpoint(2.0, false)
+        @test LeftEndpoint(1, true) <= LeftEndpoint(2.0, false)
+        @test LeftEndpoint(1, false) <= LeftEndpoint(2.0, true)
+        @test LeftEndpoint(1, true) <= LeftEndpoint(2.0, true)
 
-        @test LeftEndpoint(1, false) <= LeftEndpoint(1, false)
-        @test LeftEndpoint(1, true) <= LeftEndpoint(1, false)
-        @test !(LeftEndpoint(1, false) <= LeftEndpoint(1, true))
-        @test LeftEndpoint(1, true) <= LeftEndpoint(1, true)
+        @test LeftEndpoint(1, false) <= LeftEndpoint(1.0, false)
+        @test LeftEndpoint(1, true) <= LeftEndpoint(1.0, false)
+        @test !(LeftEndpoint(1, false) <= LeftEndpoint(1.0, true))
+        @test LeftEndpoint(1, true) <= LeftEndpoint(1.0, true)
 
-        @test !(LeftEndpoint(2, false) <= LeftEndpoint(1, false))
-        @test !(LeftEndpoint(2, true) <= LeftEndpoint(1, false))
-        @test !(LeftEndpoint(2, false) <= LeftEndpoint(1, true))
-        @test !(LeftEndpoint(2, true) <= LeftEndpoint(1, true))
+        @test !(LeftEndpoint(2, false) <= LeftEndpoint(1.0, false))
+        @test !(LeftEndpoint(2, true) <= LeftEndpoint(1.0, false))
+        @test !(LeftEndpoint(2, false) <= LeftEndpoint(1.0, true))
+        @test !(LeftEndpoint(2, true) <= LeftEndpoint(1.0, true))
     end
 
     @testset "RightEndpoint < RightEndpoint" begin
-        @test RightEndpoint(1, false) < RightEndpoint(2, false)
-        @test RightEndpoint(1, true) < RightEndpoint(2, false)
-        @test RightEndpoint(1, false) < RightEndpoint(2, true)
-        @test RightEndpoint(1, true) < RightEndpoint(2, true)
+        @test RightEndpoint(1, false) < RightEndpoint(2.0, false)
+        @test RightEndpoint(1, true) < RightEndpoint(2.0, false)
+        @test RightEndpoint(1, false) < RightEndpoint(2.0, true)
+        @test RightEndpoint(1, true) < RightEndpoint(2.0, true)
 
-        @test !(RightEndpoint(1, false) < RightEndpoint(1, false))
-        @test !(RightEndpoint(1, true) < RightEndpoint(1, false))
-        @test RightEndpoint(1, false) < RightEndpoint(1, true)
-        @test !(RightEndpoint(1, true) < RightEndpoint(1, true))
+        @test !(RightEndpoint(1, false) < RightEndpoint(1.0, false))
+        @test !(RightEndpoint(1, true) < RightEndpoint(1.0, false))
+        @test RightEndpoint(1, false) < RightEndpoint(1.0, true)
+        @test !(RightEndpoint(1, true) < RightEndpoint(1.0, true))
 
-        @test !(RightEndpoint(2, false) < RightEndpoint(1, false))
-        @test !(RightEndpoint(2, true) < RightEndpoint(1, false))
-        @test !(RightEndpoint(2, false) < RightEndpoint(1, true))
-        @test !(RightEndpoint(2, true) < RightEndpoint(1, true))
+        @test !(RightEndpoint(2, false) < RightEndpoint(1.0, false))
+        @test !(RightEndpoint(2, true) < RightEndpoint(1.0, false))
+        @test !(RightEndpoint(2, false) < RightEndpoint(1.0, true))
+        @test !(RightEndpoint(2, true) < RightEndpoint(1.0, true))
     end
 
     @testset "RightEndpoint <= RightEndpoint" begin
-        @test RightEndpoint(1, false) <= RightEndpoint(2, false)
-        @test RightEndpoint(1, true) <= RightEndpoint(2, false)
-        @test RightEndpoint(1, false) <= RightEndpoint(2, true)
-        @test RightEndpoint(1, true) <= RightEndpoint(2, true)
+        @test RightEndpoint(1, false) <= RightEndpoint(2.0, false)
+        @test RightEndpoint(1, true) <= RightEndpoint(2.0, false)
+        @test RightEndpoint(1, false) <= RightEndpoint(2.0, true)
+        @test RightEndpoint(1, true) <= RightEndpoint(2.0, true)
 
-        @test RightEndpoint(1, false) <= RightEndpoint(1, false)
-        @test !(RightEndpoint(1, true) <= RightEndpoint(1, false))
-        @test RightEndpoint(1, false) <= RightEndpoint(1, true)
-        @test RightEndpoint(1, true) <= RightEndpoint(1, true)
+        @test RightEndpoint(1, false) <= RightEndpoint(1.0, false)
+        @test !(RightEndpoint(1, true) <= RightEndpoint(1.0, false))
+        @test RightEndpoint(1, false) <= RightEndpoint(1.0, true)
+        @test RightEndpoint(1, true) <= RightEndpoint(1.0, true)
 
-        @test !(RightEndpoint(2, false) <= RightEndpoint(1, false))
-        @test !(RightEndpoint(2, true) <= RightEndpoint(1, false))
-        @test !(RightEndpoint(2, false) <= RightEndpoint(1, true))
-        @test !(RightEndpoint(2, true) <= RightEndpoint(1, true))
+        @test !(RightEndpoint(2, false) <= RightEndpoint(1.0, false))
+        @test !(RightEndpoint(2, true) <= RightEndpoint(1.0, false))
+        @test !(RightEndpoint(2, false) <= RightEndpoint(1.0, true))
+        @test !(RightEndpoint(2, true) <= RightEndpoint(1.0, true))
     end
 
     @testset "LeftEndpoint < RightEndpoint" begin
-        @test LeftEndpoint(1, false) < RightEndpoint(2, false)
-        @test LeftEndpoint(1, true) < RightEndpoint(2, false)
-        @test LeftEndpoint(1, false) < RightEndpoint(2, true)
-        @test LeftEndpoint(1, true) < RightEndpoint(2, true)
+        @test LeftEndpoint(1, false) < RightEndpoint(2.0, false)
+        @test LeftEndpoint(1, true) < RightEndpoint(2.0, false)
+        @test LeftEndpoint(1, false) < RightEndpoint(2.0, true)
+        @test LeftEndpoint(1, true) < RightEndpoint(2.0, true)
 
-        @test !(LeftEndpoint(1, false) < RightEndpoint(1, false))
-        @test !(LeftEndpoint(1, true) < RightEndpoint(1, false))
-        @test !(LeftEndpoint(1, false) < RightEndpoint(1, true))
-        @test !(LeftEndpoint(1, true) < RightEndpoint(1, true))
+        @test !(LeftEndpoint(1, false) < RightEndpoint(1.0, false))
+        @test !(LeftEndpoint(1, true) < RightEndpoint(1.0, false))
+        @test !(LeftEndpoint(1, false) < RightEndpoint(1.0, true))
+        @test !(LeftEndpoint(1, true) < RightEndpoint(1.0, true))
 
-        @test !(LeftEndpoint(2, false) < RightEndpoint(1, false))
-        @test !(LeftEndpoint(2, true) < RightEndpoint(1, false))
-        @test !(LeftEndpoint(2, false) < RightEndpoint(1, true))
-        @test !(LeftEndpoint(2, true) < RightEndpoint(1, true))
+        @test !(LeftEndpoint(2, false) < RightEndpoint(1.0, false))
+        @test !(LeftEndpoint(2, true) < RightEndpoint(1.0, false))
+        @test !(LeftEndpoint(2, false) < RightEndpoint(1.0, true))
+        @test !(LeftEndpoint(2, true) < RightEndpoint(1.0, true))
     end
 
     @testset "LeftEndpoint <= RightEndpoint" begin
-        @test LeftEndpoint(1, false) <= RightEndpoint(2, false)
-        @test LeftEndpoint(1, true) <= RightEndpoint(2, false)
-        @test LeftEndpoint(1, false) <= RightEndpoint(2, true)
-        @test LeftEndpoint(1, true) <= RightEndpoint(2, true)
+        @test LeftEndpoint(1, false) <= RightEndpoint(2.0, false)
+        @test LeftEndpoint(1, true) <= RightEndpoint(2.0, false)
+        @test LeftEndpoint(1, false) <= RightEndpoint(2.0, true)
+        @test LeftEndpoint(1, true) <= RightEndpoint(2.0, true)
 
-        @test !(LeftEndpoint(1, false) <= RightEndpoint(1, false))
-        @test !(LeftEndpoint(1, true) <= RightEndpoint(1, false))
-        @test !(LeftEndpoint(1, false) <= RightEndpoint(1, true))
-        @test LeftEndpoint(1, true) <= RightEndpoint(1, true)
+        @test !(LeftEndpoint(1, false) <= RightEndpoint(1.0, false))
+        @test !(LeftEndpoint(1, true) <= RightEndpoint(1.0, false))
+        @test !(LeftEndpoint(1, false) <= RightEndpoint(1.0, true))
+        @test LeftEndpoint(1, true) <= RightEndpoint(1.0, true)
 
-        @test !(LeftEndpoint(2, false) <= RightEndpoint(1, false))
-        @test !(LeftEndpoint(2, true) <= RightEndpoint(1, false))
-        @test !(LeftEndpoint(2, false) <= RightEndpoint(1, true))
-        @test !(LeftEndpoint(2, true) <= RightEndpoint(1, true))
+        @test !(LeftEndpoint(2, false) <= RightEndpoint(1.0, false))
+        @test !(LeftEndpoint(2, true) <= RightEndpoint(1.0, false))
+        @test !(LeftEndpoint(2, false) <= RightEndpoint(1.0, true))
+        @test !(LeftEndpoint(2, true) <= RightEndpoint(1.0, true))
     end
 
     @testset "RightEndpoint < LeftEndpoint" begin
-        @test RightEndpoint(1, false) < LeftEndpoint(2, false)
-        @test RightEndpoint(1, true) < LeftEndpoint(2, false)
-        @test RightEndpoint(1, false) < LeftEndpoint(2, true)
-        @test RightEndpoint(1, true) < LeftEndpoint(2, true)
+        @test RightEndpoint(1, false) < LeftEndpoint(2.0, false)
+        @test RightEndpoint(1, true) < LeftEndpoint(2.0, false)
+        @test RightEndpoint(1, false) < LeftEndpoint(2.0, true)
+        @test RightEndpoint(1, true) < LeftEndpoint(2.0, true)
 
-        @test RightEndpoint(1, false) < LeftEndpoint(1, false)
-        @test RightEndpoint(1, true) < LeftEndpoint(1, false)
-        @test RightEndpoint(1, false) < LeftEndpoint(1, true)
-        @test !(RightEndpoint(1, true) < LeftEndpoint(1, true))
+        @test RightEndpoint(1, false) < LeftEndpoint(1.0, false)
+        @test RightEndpoint(1, true) < LeftEndpoint(1.0, false)
+        @test RightEndpoint(1, false) < LeftEndpoint(1.0, true)
+        @test !(RightEndpoint(1, true) < LeftEndpoint(1.0, true))
 
-        @test !(RightEndpoint(2, false) < LeftEndpoint(1, false))
-        @test !(RightEndpoint(2, true) < LeftEndpoint(1, false))
-        @test !(RightEndpoint(2, false) < LeftEndpoint(1, true))
-        @test !(RightEndpoint(2, true) < LeftEndpoint(1, true))
+        @test !(RightEndpoint(2, false) < LeftEndpoint(1.0, false))
+        @test !(RightEndpoint(2, true) < LeftEndpoint(1.0, false))
+        @test !(RightEndpoint(2, false) < LeftEndpoint(1.0, true))
+        @test !(RightEndpoint(2, true) < LeftEndpoint(1.0, true))
     end
 
     @testset "RightEndpoint <= LeftEndpoint" begin
-        @test RightEndpoint(1, false) <= LeftEndpoint(2, false)
-        @test RightEndpoint(1, true) <= LeftEndpoint(2, false)
-        @test RightEndpoint(1, false) <= LeftEndpoint(2, true)
-        @test RightEndpoint(1, true) <= LeftEndpoint(2, true)
+        @test RightEndpoint(1, false) <= LeftEndpoint(2.0, false)
+        @test RightEndpoint(1, true) <= LeftEndpoint(2.0, false)
+        @test RightEndpoint(1, false) <= LeftEndpoint(2.0, true)
+        @test RightEndpoint(1, true) <= LeftEndpoint(2.0, true)
 
-        @test RightEndpoint(1, false) <= LeftEndpoint(1, false)
-        @test RightEndpoint(1, true) <= LeftEndpoint(1, false)
-        @test RightEndpoint(1, false) <= LeftEndpoint(1, true)
-        @test RightEndpoint(1, true) <= LeftEndpoint(1, true)
+        @test RightEndpoint(1, false) <= LeftEndpoint(1.0, false)
+        @test RightEndpoint(1, true) <= LeftEndpoint(1.0, false)
+        @test RightEndpoint(1, false) <= LeftEndpoint(1.0, true)
+        @test RightEndpoint(1, true) <= LeftEndpoint(1.0, true)
 
-        @test !(RightEndpoint(2, false) <= LeftEndpoint(1, false))
-        @test !(RightEndpoint(2, true) <= LeftEndpoint(1, false))
-        @test !(RightEndpoint(2, false) <= LeftEndpoint(1, true))
-        @test !(RightEndpoint(2, true) <= LeftEndpoint(1, true))
+        @test !(RightEndpoint(2, false) <= LeftEndpoint(1.0, false))
+        @test !(RightEndpoint(2, true) <= LeftEndpoint(1.0, false))
+        @test !(RightEndpoint(2, false) <= LeftEndpoint(1.0, true))
+        @test !(RightEndpoint(2, true) <= LeftEndpoint(1.0, true))
     end
 
     @testset "$Endpoint < Scalar" for Endpoint in (LeftEndpoint, RightEndpoint)
-        @test Endpoint(1, false) < 2
-        @test Endpoint(1, true) < 2
+        @test Endpoint(1, false) < 2.0
+        @test Endpoint(1, true) < 2.0
 
-        @test (Endpoint(1, false) < 1) == (Endpoint === RightEndpoint)
-        @test !(Endpoint(1, true) < 1)
+        @test (Endpoint(1, false) < 1.0) == (Endpoint === RightEndpoint)
+        @test !(Endpoint(1, true) < 1.0)
 
-        @test !(Endpoint(1, false) < 0)
-        @test !(Endpoint(1, true) < 0)
+        @test !(Endpoint(1, false) < 0.0)
+        @test !(Endpoint(1, true) < 0.0)
     end
 
     @testset "Scalar < $Endpoint" for Endpoint in (LeftEndpoint, RightEndpoint)
-        @test 0 < Endpoint(1, false)
-        @test 0 < Endpoint(1, true)
+        @test 0 < Endpoint(1.0, false)
+        @test 0 < Endpoint(1.0, true)
 
-        @test (1 < Endpoint(1, false)) == (Endpoint === LeftEndpoint)
-        @test !(1 < Endpoint(1, true))
+        @test (1 < Endpoint(1.0, false)) == (Endpoint === LeftEndpoint)
+        @test !(1 < Endpoint(1.0, true))
 
-        @test !(2 < Endpoint(1, false))
-        @test !(2 < Endpoint(1, true))
+        @test !(2 < Endpoint(1.0, false))
+        @test !(2 < Endpoint(1.0, true))
     end
 
     @testset "LeftEndpoint == LeftEndpoint" begin
-        @test LeftEndpoint(1, false) != LeftEndpoint(2, false)
-        @test LeftEndpoint(1, true) != LeftEndpoint(2, false)
-        @test LeftEndpoint(1, false) != LeftEndpoint(2, true)
-        @test LeftEndpoint(1, true) != LeftEndpoint(2, true)
+        @test LeftEndpoint(1, false) != LeftEndpoint(2.0, false)
+        @test LeftEndpoint(1, true) != LeftEndpoint(2.0, false)
+        @test LeftEndpoint(1, false) != LeftEndpoint(2.0, true)
+        @test LeftEndpoint(1, true) != LeftEndpoint(2.0, true)
 
-        @test LeftEndpoint(1, false) == LeftEndpoint(1, false)
-        @test LeftEndpoint(1, true) != LeftEndpoint(1, false)
-        @test LeftEndpoint(1, false) != LeftEndpoint(1, true)
-        @test LeftEndpoint(1, true) == LeftEndpoint(1, true)
+        @test LeftEndpoint(1, false) == LeftEndpoint(1.0, false)
+        @test LeftEndpoint(1, true) != LeftEndpoint(1.0, false)
+        @test LeftEndpoint(1, false) != LeftEndpoint(1.0, true)
+        @test LeftEndpoint(1, true) == LeftEndpoint(1.0, true)
     end
 
     @testset "RightEndpoint == RightEndpoint" begin
-        @test RightEndpoint(1, false) != RightEndpoint(2, false)
-        @test RightEndpoint(1, true) != RightEndpoint(2, false)
-        @test RightEndpoint(1, false) != RightEndpoint(2, true)
-        @test RightEndpoint(1, true) != RightEndpoint(2, true)
+        @test RightEndpoint(1, false) != RightEndpoint(2.0, false)
+        @test RightEndpoint(1, true) != RightEndpoint(2.0, false)
+        @test RightEndpoint(1, false) != RightEndpoint(2.0, true)
+        @test RightEndpoint(1, true) != RightEndpoint(2.0, true)
 
-        @test RightEndpoint(1, false) == RightEndpoint(1, false)
-        @test RightEndpoint(1, true) != RightEndpoint(1, false)
-        @test RightEndpoint(1, false) != RightEndpoint(1, true)
-        @test RightEndpoint(1, true) == RightEndpoint(1, true)
+        @test RightEndpoint(1, false) == RightEndpoint(1.0, false)
+        @test RightEndpoint(1, true) != RightEndpoint(1.0, false)
+        @test RightEndpoint(1, false) != RightEndpoint(1.0, true)
+        @test RightEndpoint(1, true) == RightEndpoint(1.0, true)
     end
 
     @testset "LeftEndpoint == RightEndpoint" begin
-        @test LeftEndpoint(1, false) != RightEndpoint(2, false)
-        @test LeftEndpoint(1, true) != RightEndpoint(2, false)
-        @test LeftEndpoint(1, false) != RightEndpoint(2, true)
-        @test LeftEndpoint(1, true) != RightEndpoint(2, true)
+        @test LeftEndpoint(1, false) != RightEndpoint(2.0, false)
+        @test LeftEndpoint(1, true) != RightEndpoint(2.0, false)
+        @test LeftEndpoint(1, false) != RightEndpoint(2.0, true)
+        @test LeftEndpoint(1, true) != RightEndpoint(2.0, true)
 
-        @test LeftEndpoint(1, false) != RightEndpoint(1, false)
-        @test LeftEndpoint(1, true) != RightEndpoint(1, false)
-        @test LeftEndpoint(1, false) != RightEndpoint(1, true)
-        @test LeftEndpoint(1, true) == RightEndpoint(1, true)
+        @test LeftEndpoint(1, false) != RightEndpoint(1.0, false)
+        @test LeftEndpoint(1, true) != RightEndpoint(1.0, false)
+        @test LeftEndpoint(1, false) != RightEndpoint(1.0, true)
+        @test LeftEndpoint(1, true) == RightEndpoint(1.0, true)
     end
 
     @testset "RightEndpoint == LeftEndpoint" begin
-        @test RightEndpoint(1, false) != LeftEndpoint(2, false)
-        @test RightEndpoint(1, true) != LeftEndpoint(2, false)
-        @test RightEndpoint(1, false) != LeftEndpoint(2, true)
-        @test RightEndpoint(1, true) != LeftEndpoint(2, true)
+        @test RightEndpoint(1, false) != LeftEndpoint(2.0, false)
+        @test RightEndpoint(1, true) != LeftEndpoint(2.0, false)
+        @test RightEndpoint(1, false) != LeftEndpoint(2.0, true)
+        @test RightEndpoint(1, true) != LeftEndpoint(2.0, true)
 
-        @test RightEndpoint(1, false) != LeftEndpoint(1, false)
-        @test RightEndpoint(1, true) != LeftEndpoint(1, false)
-        @test RightEndpoint(1, false) != LeftEndpoint(1, true)
-        @test RightEndpoint(1, true) == LeftEndpoint(1, true)
+        @test RightEndpoint(1, false) != LeftEndpoint(1.0, false)
+        @test RightEndpoint(1, true) != LeftEndpoint(1.0, false)
+        @test RightEndpoint(1, false) != LeftEndpoint(1.0, true)
+        @test RightEndpoint(1, true) == LeftEndpoint(1.0, true)
     end
 end


### PR DESCRIPTION
While updating the documentation for `==(::Endpoint, ::Endpoint)` I noticed that the type parameters for the conditionals was unnecessary and would make `Intervals.RightEndpoint(1, true) < Intervals.LeftEndpoint(1.0, false)` result in a `MethodError`. The tests were updated to always use mixed type endpoints.