### PR TITLE
Add superset function

### DIFF
--- a/src/Intervals.jl
+++ b/src/Intervals.jl
@@ -41,5 +41,6 @@ export AbstractInterval,
        union!,
        less_than_disjoint,
        greater_than_disjoint,
+       superset,
        .., ≪, ≫, ⊆, ⊇, ⊈, ⊉
 end

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -84,6 +84,13 @@ Interval(f, l, inc...) = Interval(promote(f, l)..., inc...)
 Interval(interval::AbstractInterval) = convert(Interval, interval)
 Interval{T}(interval::AbstractInterval) where T = convert(Interval{T}, interval)
 
+# Endpoint constructors
+function Interval{T}(left::LeftEndpoint{T}, right::RightEndpoint{T}) where T
+    Interval{T}(left.endpoint, right.endpoint, left.included, right.included)
+end
+
+Interval(left::LeftEndpoint{T}, right::RightEndpoint{T}) where T = Interval{T}(left, right)
+
 # Empty Intervals
 Interval{T}() where T = Interval{T}(zero(T), zero(T), Inclusivity(false, false))
 Interval{T}() where T <: TimeType = Interval{T}(T(0), T(0), Inclusivity(false, false))
@@ -250,7 +257,7 @@ function Base.intersect(a::AbstractInterval{T}, b::AbstractInterval{T}) where T
     left = max(LeftEndpoint(a), LeftEndpoint(b))
     right = min(RightEndpoint(a), RightEndpoint(b))
 
-    return Interval{T}(left.endpoint, right.endpoint, left.included, right.included)
+    return Interval{T}(left, right)
 end
 
 # There is power in a union.
@@ -302,11 +309,7 @@ function Base.merge(a::AbstractInterval, b::AbstractInterval)
 
     left = min(LeftEndpoint(a), LeftEndpoint(b))
     right = max(RightEndpoint(a), RightEndpoint(b))
-    return Interval(
-        left.endpoint,
-        right.endpoint,
-        Inclusivity(left.included, right.included)
-    )
+    return Interval(left, right)
 end
 
 ##### TIME ZONES #####

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -302,6 +302,18 @@ function Base.union!(intervals::Union{AbstractVector{<:Interval}, AbstractVector
     return intervals
 end
 
+"""
+    superset(intervals::AbstractArray{<:AbstractInterval}) -> Interval
+
+Create the smallest single interval which encompasses all of the provided intervals.
+"""
+function superset(intervals::AbstractArray{<:AbstractInterval})
+    left = minimum(LeftEndpoint.(intervals))
+    right = maximum(RightEndpoint.(intervals))
+
+    return Interval(left, right)
+end
+
 function Base.merge(a::AbstractInterval, b::AbstractInterval)
     if !overlaps(a, b) && !contiguous(a, b)
         throw(ArgumentError("$a and $b are neither overlapping or contiguous."))

--- a/test/comparisons.jl
+++ b/test/comparisons.jl
@@ -42,6 +42,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([earlier, later]) == [earlier, later]
         @test !overlaps(earlier, later)
         @test !contiguous(earlier, later)
+        @test superset([earlier, later]) == Interval(1, 5, true, true)
     end
 
     # Compare two intervals which "touch" but both intervals do not include that point:
@@ -74,6 +75,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([earlier, later]) == [earlier, later]
         @test !overlaps(earlier, later)
         @test !contiguous(earlier, later)
+        @test superset([earlier, later]) == Interval(1, 5, false, false)
     end
 
     # Compare two intervals which "touch" and the later interval includes that point:
@@ -106,6 +108,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([earlier, later]) == [Interval(1, 5, false, true)]
         @test !overlaps(earlier, later)
         @test contiguous(earlier, later)
+        @test superset([earlier, later]) == Interval(1, 5, false, true)
     end
 
     # Compare two intervals which "touch" and the earlier interval includes that point:
@@ -138,6 +141,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([earlier, later]) == [Interval(1, 5, true, false)]
         @test !overlaps(earlier, later)
         @test contiguous(earlier, later)
+        @test superset([earlier, later]) == Interval(1, 5, true, false)
     end
 
     # Compare two intervals which "touch" and both intervals include that point:
@@ -170,6 +174,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([earlier, later]) == [Interval(1, 5, true, true)]
         @test overlaps(earlier, later)
         @test !contiguous(earlier, later)
+        @test superset([earlier, later]) == Interval(1, 5, true, true)
     end
 
     # Compare two intervals which overlap
@@ -202,6 +207,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([earlier, later]) == [Interval(1, 5, true, true)]
         @test overlaps(earlier, later)
         @test !contiguous(earlier, later)
+        @test superset([earlier, later]) == Interval(1, 5, true, true)
     end
 
     @testset "equal ()/()" begin
@@ -229,6 +235,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([a, b]) == [Interval(1, 5, false, false)]
         @test overlaps(a, b)
         @test !contiguous(a, b)
+        @test superset([a, b]) == Interval(1, 5, false, false)
     end
 
     @testset "equal [)/()" begin
@@ -256,6 +263,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([a, b]) == [Interval(1, 5, true, false)]
         @test overlaps(a, b)
         @test !contiguous(a, b)
+        @test superset([a, b]) == Interval(1, 5, true, false)
     end
 
     @testset "equal (]/()" begin
@@ -283,6 +291,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([a, b]) == [Interval(1, 5, false, true)]
         @test overlaps(a, b)
         @test !contiguous(a, b)
+        @test superset([a, b]) == Interval(1, 5, false, true)
     end
 
     @testset "equal []/()" begin
@@ -310,6 +319,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([a, b]) == [Interval(1, 5, true, true)]
         @test overlaps(a, b)
         @test !contiguous(a, b)
+        @test superset([a, b]) == Interval(1, 5, true, true)
     end
 
     @testset "equal [)/[]" begin
@@ -337,6 +347,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([a, b]) == [Interval(1, 5, true, true)]
         @test overlaps(a, b)
         @test !contiguous(a, b)
+        @test superset([a, b]) == Interval(1, 5, true, true)
     end
 
     @testset "equal (]/[]" begin
@@ -364,6 +375,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([a, b]) == [Interval(1, 5, true, true)]
         @test overlaps(a, b)
         @test !contiguous(a, b)
+        @test superset([a, b]) == Interval(1, 5, true, true)
     end
 
     @testset "equal []/[]" begin
@@ -391,6 +403,7 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([a, b]) == [Interval(1, 5, true, true)]
         @test overlaps(a, b)
         @test !contiguous(a, b)
+        @test superset([a, b]) == Interval(1, 5, true, true)
     end
 
     # Compare two intervals where the first interval is contained by the second
@@ -423,5 +436,6 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test union([smaller, larger]) == [Interval(larger)]
         @test overlaps(smaller, larger)
         @test !contiguous(smaller, larger)
+        @test superset([smaller, larger]) == Interval(1, 5, true, true)
     end
 end


### PR DESCRIPTION
- Add `superset` function that creates an interval which encompasses all of the intervals within an array
- ~Rename interval check functions to start with "is" (with deprecations)~
- Add `Interval` constructor which takes `Endpoint`s