### PR TITLE
Implement `eltype`

### DIFF
--- a/src/Intervals.jl
+++ b/src/Intervals.jl
@@ -14,6 +14,8 @@ import Base: ⊆, ⊇, ⊈, ⊉, union, union!, merge
 
 abstract type AbstractInterval{T} end
 
+Base.eltype(::AbstractInterval{T}) where {T} = T
+
 include("inclusivity.jl")
 include("endpoint.jl")
 include("interval.jl")

--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -65,22 +65,21 @@ struct AnchoredInterval{P, T} <: AbstractInterval{T}
     inclusivity::Inclusivity
 end
 
+function AnchoredInterval{P, T}(i::T, x::Bool, y::Bool) where {P, T}
+    return AnchoredInterval{P, T}(i, Inclusivity(x, y))
+end
+
 # When an interval is anchored to the lesser endpoint, default to Inclusivity(false, true)
 # When an interval is anchored to the greater endpoint, default to Inclusivity(true, false)
 function AnchoredInterval{P, T}(i::T) where {P, T}
     return AnchoredInterval{P, T}(i::T, Inclusivity(P ≥ zero(P), P ≤ zero(P)))
 end
 
-AnchoredInterval{P}(i::T, inc::Inclusivity) where {P, T} = AnchoredInterval{P, T}(i, inc)
-AnchoredInterval{P}(i::T) where {P, T} = AnchoredInterval{P, T}(i)
-
-function AnchoredInterval{P, T}(i::T, x::Bool, y::Bool) where {P, T}
-    return AnchoredInterval{P, T}(i, Inclusivity(x, y))
+function AnchoredInterval{P, T}(i, inc...) where {P, T}
+    return AnchoredInterval{P, T}(convert(T, i), inc...)
 end
 
-function AnchoredInterval{P}(i::T, x::Bool, y::Bool) where {P, T}
-    return AnchoredInterval{P, T}(i, Inclusivity(x, y))
-end
+AnchoredInterval{P}(i::T, inc...) where {P, T} = AnchoredInterval{P, T}(i, inc...)
 
 """
     HourEnding{T<:TimeType} <: AbstractInterval{T}

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -71,11 +71,14 @@ struct Interval{T} <: AbstractInterval{T}
     end
 end
 
-Interval(f::T, l::T, inclusivity) where T = Interval{T}(f, l, inclusivity)
-Interval{T}(f, l, x::Bool, y::Bool) where T = Interval{T}(f, l, Inclusivity(x, y))
-Interval(f, l, x::Bool, y::Bool) = Interval(f, l, Inclusivity(x, y))
-Interval(f::T, l::T) where T = Interval(f, l, Inclusivity(true, true))
-(..)(f::T, l::T) where T = Interval(f, l)
+Interval{T}(f::T, l::T, x::Bool, y::Bool) where T = Interval{T}(f, l, Inclusivity(x, y))
+Interval{T}(f::T, l::T) where T = Interval{T}(f, l, Inclusivity(true, true))
+Interval(f::T, l::T, inc...) where T = Interval{T}(f, l, inc...)
+
+Interval{T}(f, l, inc...) where T = Interval{T}(convert(T, f), convert(T, l), inc...)
+Interval(f, l, inc...) = Interval(promote(f, l)..., inc...)
+
+(..)(first, last) = Interval(first, last)
 
 # In Julia 0.7 constructors no longer automatically fall back to using `convert`
 Interval(interval::AbstractInterval) = convert(Interval, interval)

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -49,6 +49,14 @@ using Intervals: canonicalize
         @test convert(Interval{DateTime}, hb) == Interval(dt, dt + Hour(1), Inclusivity(true, false))
     end
 
+    @testset "eltype" begin
+        @test eltype(AnchoredInterval{-10}(10)) == Int
+        @test eltype(AnchoredInterval{25}('a')) == Char
+        @test eltype(AnchoredInterval{Day(1)}(today())) == Date
+        @test eltype(AnchoredInterval{Day(1),DateTime}(today())) == DateTime
+        @test eltype(HourEnding(now())) == DateTime
+    end
+
     @testset "accessors" begin
         inc = Inclusivity(true, true)
         P = Minute(-15)

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -50,6 +50,11 @@
         end
     end
 
+    @testset "eltype" begin
+        @test eltype(Interval(1,2)) == Int
+        @test eltype(Interval{Float64}(1,2)) == Float64
+    end
+
     @testset "accessors" begin
         for (a, b, _) in test_values
             for i in 0:3


### PR DESCRIPTION
While writing the tests I noticed there wasn't a constructor which handled promotion to the `Interval` element type (e.g. `Interval{Float64}(1,2)`) so I also implemented that and in the process cleaned up the constructors.