### PR TITLE
Define hash methods

### DIFF
--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -119,6 +119,15 @@ function Base.copy(x::AnchoredInterval{P, T}) where {P, T}
     return AnchoredInterval{P, T}(anchor(x), inclusivity(x))
 end
 
+function Base.hash(interval::AnchoredInterval{P}, h::UInt) where P
+    # Note: we shouldn't need to hash the second type parameter of an AnchoredInterval as
+    # that information should be covered by the anchor field.
+    h = hash(:AnchoredInterval, h)
+    h = hash(P, h)
+    h = hash(interval.anchor, h)
+    return hash(interval.inclusivity, h)
+end
+
 ##### ACCESSORS #####
 
 Base.first(interval::AnchoredInterval{P}) where P = min(interval.anchor, interval.anchor+P)

--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -119,15 +119,6 @@ function Base.copy(x::AnchoredInterval{P, T}) where {P, T}
     return AnchoredInterval{P, T}(anchor(x), inclusivity(x))
 end
 
-function Base.hash(interval::AnchoredInterval{P}, h::UInt) where P
-    # Note: we shouldn't need to hash the second type parameter of an AnchoredInterval as
-    # that information should be covered by the anchor field.
-    h = hash(:AnchoredInterval, h)
-    h = hash(P, h)
-    h = hash(interval.anchor, h)
-    return hash(interval.inclusivity, h)
-end
-
 ##### ACCESSORS #####
 
 Base.first(interval::AnchoredInterval{P}) where P = min(interval.anchor, interval.anchor+P)

--- a/src/endpoint.jl
+++ b/src/endpoint.jl
@@ -26,6 +26,14 @@ RightEndpoint(ep::T, included::Bool) where T = RightEndpoint{T}(ep, included)
 LeftEndpoint(i::AbstractInterval{T}) where T = LeftEndpoint{T}(first(i), first(inclusivity(i)))
 RightEndpoint(i::AbstractInterval{T}) where T = RightEndpoint{T}(last(i), last(inclusivity(i)))
 
+function Base.hash(x::Endpoint{T, D}, h::UInt) where {T, D}
+    # Note: we shouldn't need to hash `T` as this is covered by the endpoint field.
+    h = hash(:Endpoint, h)
+    h = hash(D, h)
+    h = hash(x.endpoint, h)
+    h = hash(x.included, h)
+    return h
+end
 
 """
     ==(a::Endpoint, b::Endpoint) -> Bool

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -101,6 +101,13 @@ end
 
 Base.copy(x::Interval{T}) where T = Interval{T}(x.first, x.last, x.inclusivity)
 
+function Base.hash(interval::Interval, h::UInt)
+    h = hash(:Interval, h)
+    h = hash(interval.first, h)
+    h = hash(interval.last, h)
+    return hash(interval.inclusivity, h)
+end
+
 ##### ACCESSORS #####
 
 Base.first(interval::Interval) = interval.first

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -101,11 +101,10 @@ end
 
 Base.copy(x::Interval{T}) where T = Interval{T}(x.first, x.last, x.inclusivity)
 
-function Base.hash(interval::Interval, h::UInt)
-    h = hash(:Interval, h)
-    h = hash(interval.first, h)
-    h = hash(interval.last, h)
-    return hash(interval.inclusivity, h)
+function Base.hash(interval::AbstractInterval, h::UInt)
+    h = hash(LeftEndpoint(interval), h)
+    h = hash(RightEndpoint(interval), h)
+    return h
 end
 
 ##### ACCESSORS #####

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -36,6 +36,14 @@ using Intervals: canonicalize
         @test AnchoredInterval{25}('a') isa AnchoredInterval
     end
 
+    @testset "hash" begin
+        # Need a complicated enough element type for this test to ever fail
+        zdt = now(tz"Europe/London")
+        a = HE(zdt)
+        b = deepcopy(a)
+        @test hash(a) == hash(b)
+    end
+
     @testset "conversion" begin
         he = HourEnding(dt)
         hb = HourBeginning(dt)

--- a/test/comparisons.jl
+++ b/test/comparisons.jl
@@ -215,8 +215,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         b = convert(B, Interval(1, 5, false, false))
 
         @test a == b
-        @test A != B || isequal(a, b)
-        @test A != B || hash(a) == hash(b)
+        @test isequal(a, b)
+        @test hash(a) == hash(b)
 
         @test !isless(a, b)
         @test !isless(a, b)
@@ -383,8 +383,8 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         b = convert(B, Interval(1, 5, true, true))
 
         @test a == b
-        @test A != B || isequal(a, b)
-        @test A != B || hash(a) == hash(b)
+        @test isequal(a, b)
+        @test hash(a) == hash(b)
 
         @test !isless(a, b)
         @test !isless(b, a)

--- a/test/endpoint.jl
+++ b/test/endpoint.jl
@@ -206,4 +206,27 @@ using Intervals: LeftEndpoint, RightEndpoint
         @test RightEndpoint(1, false) != LeftEndpoint(1.0, true)
         @test RightEndpoint(1, true) == LeftEndpoint(1.0, true)
     end
+
+    @testset "hash" begin
+        # Need a complicated enough element type for this test to possibly fail. Using a
+        # ZonedDateTime with a VariableTimeZone should do the trick.
+        a = now(tz"Europe/London")
+        b = deepcopy(a)
+        @test hash(a) == hash(b)  # Double check
+
+        @test hash(LeftEndpoint(a, false)) == hash(LeftEndpoint(b, false))
+        @test hash(LeftEndpoint(a, true)) != hash(LeftEndpoint(b, false))
+        @test hash(LeftEndpoint(a, false)) != hash(LeftEndpoint(b, true))
+        @test hash(LeftEndpoint(a, true)) == hash(LeftEndpoint(b, true))
+
+        @test hash(RightEndpoint(a, false)) == hash(RightEndpoint(b, false))
+        @test hash(RightEndpoint(a, true)) != hash(RightEndpoint(b, false))
+        @test hash(RightEndpoint(a, false)) != hash(RightEndpoint(b, true))
+        @test hash(RightEndpoint(a, true)) == hash(RightEndpoint(b, true))
+
+        @test hash(LeftEndpoint(a, false)) != hash(RightEndpoint(b, false))
+        @test hash(LeftEndpoint(a, true)) != hash(RightEndpoint(b, false))
+        @test hash(LeftEndpoint(a, false)) != hash(RightEndpoint(b, true))
+        @test hash(LeftEndpoint(a, true)) != hash(RightEndpoint(b, true))
+    end
 end

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -37,6 +37,14 @@
         @test_throws MethodError Interval(1, 2, 3)
     end
 
+    @testset "hash" begin
+        # Need a complicated enough element type for this test to ever fail
+        zdt = now(tz"Europe/London")
+        a = Interval(zdt, zdt)
+        b = deepcopy(a)
+        @test hash(a) == hash(b)
+    end
+
     @testset "conversion" begin
         @test_throws DomainError convert(Int, Interval(10, 10, Inclusivity(false, false)))
         @test_throws DomainError convert(Int, Interval(10, 10, Inclusivity(false, true)))


### PR DESCRIPTION
Addresses this problem:
```julia
julia> using Intervals, TimeZones

julia> n = now(tz"America/Winnipeg")
2018-07-25T15:06:54.901-05:00

julia> a = Interval(n, n)
Interval{TimeZones.ZonedDateTime}(2018-07-25T15:06:54.901-05:00, 2018-07-25T15:06:54.901-05:00, Inclusivity(true, true))

julia> b = deepcopy(a)
Interval{TimeZones.ZonedDateTime}(2018-07-25T15:06:54.901-05:00, 2018-07-25T15:06:54.901-05:00, Inclusivity(true, true))

julia> hash(a) == hash(b)
false

julia> isequal(a, b)
true
```
