### PR TITLE
Fix Scalar and Endpoint equality

### DIFF
--- a/src/endpoint.jl
+++ b/src/endpoint.jl
@@ -6,9 +6,6 @@ const Right = Direction{:Right}()
 const Beginning = Left
 const Ending = Right
 
-const First = Left
-const Last = Right
-
 struct Endpoint{T, D}
     endpoint::T
     included::Bool
@@ -60,14 +57,6 @@ function Base.:(==)(a::Endpoint, b::Endpoint)
     a.endpoint == b.endpoint && a.included == b.included
 end
 
-function Base.:(==)(a::LeftEndpoint, b::LeftEndpoint)
-    a.endpoint == b.endpoint && a.included == b.included
-end
-
-function Base.:(==)(a::RightEndpoint, b::RightEndpoint)
-    a.endpoint == b.endpoint && a.included == b.included
-end
-
 function Base.:(==)(a::LeftEndpoint, b::RightEndpoint)
     a.endpoint == b.endpoint && a.included && b.included
 end
@@ -76,31 +65,7 @@ function Base.:(==)(a::RightEndpoint, b::LeftEndpoint)
     b == a
 end
 
-function Base.:(==)(a, b::LeftEndpoint)
-    a == b.endpoint && b.included
-end
-
-function Base.:(==)(a, b::RightEndpoint)
-    a == b.endpoint && b.included
-end
-
-function Base.:(==)(a::LeftEndpoint, b)
-    b == a
-end
-
-function Base.:(==)(a::RightEndpoint, b)
-    b == a
-end
-
 function Base.isequal(a::Endpoint, b::Endpoint)
-    isequal(a.endpoint, b.endpoint) && isequal(a.included, b.included)
-end
-
-function Base.isequal(a::LeftEndpoint, b::LeftEndpoint)
-    isequal(a.endpoint, b.endpoint) && isequal(a.included, b.included)
-end
-
-function Base.isequal(a::RightEndpoint, b::RightEndpoint)
     isequal(a.endpoint, b.endpoint) && isequal(a.included, b.included)
 end
 
@@ -128,18 +93,11 @@ function Base.isless(a::RightEndpoint, b::LeftEndpoint)
     a.endpoint < b.endpoint || (a.endpoint == b.endpoint && !(a.included && b.included))
 end
 
-function Base.isless(a, b::LeftEndpoint)
-    a < b.endpoint || (a == b.endpoint && !b.included)
-end
+# Comparisons between Scalars and Endpoints
+Base.:(==)(a, b::Endpoint) = a == b.endpoint && b.included
+Base.:(==)(a::Endpoint, b) = b == a
 
-function Base.isless(a, b::RightEndpoint)
-    a < b.endpoint
-end
-
-function Base.isless(a::LeftEndpoint, b)
-    a.endpoint < b
-end
-
-function Base.isless(a::RightEndpoint, b)
-    a.endpoint < b || (a.endpoint == b && !a.included)
-end
+Base.isless(a, b::LeftEndpoint)  = a < b.endpoint || (a == b.endpoint && !b.included)
+Base.isless(a, b::RightEndpoint) = a < b.endpoint
+Base.isless(a::LeftEndpoint, b)  = a.endpoint < b
+Base.isless(a::RightEndpoint, b) = a.endpoint < b || (a.endpoint == b && !a.included)

--- a/src/endpoint.jl
+++ b/src/endpoint.jl
@@ -6,6 +6,8 @@ const Right = Direction{:Right}()
 const Beginning = Left
 const Ending = Right
 
+const First = Left
+const Last = Right
 
 struct Endpoint{T, D}
     endpoint::T
@@ -58,15 +60,47 @@ function Base.:(==)(a::Endpoint, b::Endpoint)
     a.endpoint == b.endpoint && a.included == b.included
 end
 
+function Base.:(==)(a::LeftEndpoint, b::LeftEndpoint)
+    a.endpoint == b.endpoint && a.included == b.included
+end
+
+function Base.:(==)(a::RightEndpoint, b::RightEndpoint)
+    a.endpoint == b.endpoint && a.included == b.included
+end
+
 function Base.:(==)(a::LeftEndpoint, b::RightEndpoint)
     a.endpoint == b.endpoint && a.included && b.included
 end
 
 function Base.:(==)(a::RightEndpoint, b::LeftEndpoint)
-    a.endpoint == b.endpoint && a.included && b.included
+    b == a
+end
+
+function Base.:(==)(a, b::LeftEndpoint)
+    a == b.endpoint && b.included
+end
+
+function Base.:(==)(a, b::RightEndpoint)
+    a == b.endpoint && b.included
+end
+
+function Base.:(==)(a::LeftEndpoint, b)
+    b == a
+end
+
+function Base.:(==)(a::RightEndpoint, b)
+    b == a
 end
 
 function Base.isequal(a::Endpoint, b::Endpoint)
+    isequal(a.endpoint, b.endpoint) && isequal(a.included, b.included)
+end
+
+function Base.isequal(a::LeftEndpoint, b::LeftEndpoint)
+    isequal(a.endpoint, b.endpoint) && isequal(a.included, b.included)
+end
+
+function Base.isequal(a::RightEndpoint, b::RightEndpoint)
     isequal(a.endpoint, b.endpoint) && isequal(a.included, b.included)
 end
 
@@ -75,7 +109,7 @@ function Base.isequal(a::LeftEndpoint, b::RightEndpoint)
 end
 
 function Base.isequal(a::RightEndpoint, b::LeftEndpoint)
-    isequal(a.endpoint, b.endpoint) && a.included && b.included
+    isequal(b, a)
 end
 
 function Base.isless(a::LeftEndpoint, b::LeftEndpoint)
@@ -86,12 +120,12 @@ function Base.isless(a::RightEndpoint, b::RightEndpoint)
     a.endpoint < b.endpoint || (a.endpoint == b.endpoint && !a.included && b.included)
 end
 
-function Base.isless(a::RightEndpoint, b::LeftEndpoint)
-    a.endpoint < b.endpoint || (a.endpoint == b.endpoint && !(a.included && b.included))
-end
-
 function Base.isless(a::LeftEndpoint, b::RightEndpoint)
     a.endpoint < b.endpoint
+end
+
+function Base.isless(a::RightEndpoint, b::LeftEndpoint)
+    a.endpoint < b.endpoint || (a.endpoint == b.endpoint && !(a.included && b.included))
 end
 
 function Base.isless(a, b::LeftEndpoint)

--- a/test/endpoint.jl
+++ b/test/endpoint.jl
@@ -148,6 +148,17 @@ using Intervals: LeftEndpoint, RightEndpoint
         @test !(Endpoint(1, true) < 0.0)
     end
 
+    @testset "$Endpoint <= Scalar" for Endpoint in (LeftEndpoint, RightEndpoint)
+        @test Endpoint(1, false) <= 2.0
+        @test Endpoint(1, true) <= 2.0
+
+        @test (Endpoint(1, false) <= 1.0) == (Endpoint === RightEndpoint)
+        @test Endpoint(1, true) <= 1.0
+
+        @test !(Endpoint(1, false) <= 0.0)
+        @test !(Endpoint(1, true) <= 0.0)
+    end
+
     @testset "Scalar < $Endpoint" for Endpoint in (LeftEndpoint, RightEndpoint)
         @test 0 < Endpoint(1.0, false)
         @test 0 < Endpoint(1.0, true)
@@ -157,6 +168,17 @@ using Intervals: LeftEndpoint, RightEndpoint
 
         @test !(2 < Endpoint(1.0, false))
         @test !(2 < Endpoint(1.0, true))
+    end
+
+    @testset "Scalar <= $Endpoint" for Endpoint in (LeftEndpoint, RightEndpoint)
+        @test 0 <= Endpoint(1.0, false)
+        @test 0 <= Endpoint(1.0, true)
+
+        @test (1 <= Endpoint(1.0, false)) == (Endpoint === LeftEndpoint)
+        @test 1 <= Endpoint(1.0, true)
+
+        @test !(2 <= Endpoint(1.0, false))
+        @test !(2 <= Endpoint(1.0, true))
     end
 
     @testset "LeftEndpoint == LeftEndpoint" begin
@@ -205,6 +227,28 @@ using Intervals: LeftEndpoint, RightEndpoint
         @test RightEndpoint(1, true) != LeftEndpoint(1.0, false)
         @test RightEndpoint(1, false) != LeftEndpoint(1.0, true)
         @test RightEndpoint(1, true) == LeftEndpoint(1.0, true)
+    end
+
+    @testset "$Endpoint == Scalar" for Endpoint in (LeftEndpoint, RightEndpoint)
+        @test Endpoint(0, false) != 1.0
+        @test Endpoint(0, true) != 1.0
+
+        @test Endpoint(1, false) != 1.0
+        @test Endpoint(1, true) == 1.0
+
+        @test Endpoint(2, false) != 1.0
+        @test Endpoint(2, true) != 1.0
+    end
+
+    @testset "Scalar == $Endpoint" for Endpoint in (LeftEndpoint, RightEndpoint)
+        @test 1.0 != Endpoint(0, false)
+        @test 1.0 != Endpoint(0, true)
+
+        @test 1.0 != Endpoint(1, false)
+        @test 1.0 == Endpoint(1, true)
+
+        @test 1.0 != Endpoint(2, false)
+        @test 1.0 != Endpoint(2, true)
     end
 
     @testset "isequal" begin


### PR DESCRIPTION
This fixes the "==" issue in #54 
Also adds the Left/Right consts. 


- Added == functions for (left,left), (right,right), (scalar,left),
(scalar, right), (left, scalar), (right, scalar)
- Added isequal functions for (left,left) and (right,right)
- Changed some functions to not be repetitions of previous code such as
Left == Right code will just call Right == Left instead of redefining
the same code within both functions.
- Added First = Left, and Last = Right shortcuts.
- Added some more Scalar tests because why not