### PR TITLE
Allow `in` with mixed types

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -243,7 +243,12 @@ true
 ##### SET OPERATIONS #####
 
 Base.isempty(i::AbstractInterval) = LeftEndpoint(i) > RightEndpoint(i)
-Base.in(a::T, b::AbstractInterval{T}) where T = !(a ≫ b || a ≪ b)
+Base.in(a, b::AbstractInterval) = !(a ≫ b || a ≪ b)
+
+function Base.in(a::AbstractInterval, b::AbstractInterval)
+    # Intervals should be compared with set operations
+    throw(ArgumentError("Intervals can not be compared with `in`. Use `issubset` instead."))
+end
 
 function Base.issubset(a::AbstractInterval, b::AbstractInterval)
     return LeftEndpoint(a) ≥ LeftEndpoint(b) && RightEndpoint(a) ≤ RightEndpoint(b)

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -1,6 +1,7 @@
 @testset "Interval" begin
     test_values = [
         (-10, 1000, 1),
+        (0.0, 1, 0.01),  # Use different types to test promotion
         ('a', 'z', 1),
         (Date(2013, 2, 13), Date(2013, 3, 13), Day(1)),
         (DateTime(2016, 8, 11, 0, 30), DateTime(2016, 8, 11, 1), Millisecond(1))
@@ -384,7 +385,7 @@
             @test in(b - unit, interval)
             @test !in(b + unit, interval)
 
-            @test_throws MethodError (in(Interval(a, b), Interval(a, b)))
+            @test_throws ArgumentError (in(Interval(a, b), Interval(a, b)))
         end
     end
 


### PR DESCRIPTION
Fixes: https://github.com/invenia/Intervals.jl/issues/60