### PR TITLE
Modify tests for Date/DateTime repr changes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - julia_version: 0.6
     - julia_version: 0.7
     - julia_version: 1
     - julia_version: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
   - 1.0
   - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.7
 TimeZones 0.7
 Compat 0.62.0

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,7 @@ makedocs(;
 deploydocs(;
     repo="github.com/invenia/Intervals.jl",
     target="build",
-    julia="0.6",
+    julia="1.0",
     deps=nothing,
     make=nothing,
 )

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -114,8 +114,16 @@
         interval = Interval(Date(2012), Date(2013), Inclusivity(true, false))
         @test string(interval) == "[2012-01-01 .. 2013-01-01)"
         @test sprint(show, interval, context=:compact=>true) == string(interval)
-        @test sprint(show, interval) ==
-            "Interval{Date}(2012-01-01, 2013-01-01, Inclusivity(true, false))"
+        if VERSION < v"1.2.0-DEV.29"
+            @test sprint(show, interval) == string(
+                "Interval{Date}(2012-01-01, 2013-01-01, Inclusivity(true, false))"
+            )
+        else
+            @test sprint(show, interval) == string(
+                "Interval{Date}",
+                "(Date(2012, 1, 1), Date(2013, 1, 1), Inclusivity(true, false))",
+            )
+        end
 
         interval = Interval("a", "b", Inclusivity(true, true))
         @test string(interval) == "[a .. b]"


### PR DESCRIPTION
In Julia v"1.2.0-DEV.29" Date and DateTime repr changed from
"yyyy-mm-dd" to "Date(yyyy, m, d)", and similarly with DateTime. This
changed that comes out of show, so the tests that check the output
string of Intervals with Dates and DateTimes had to be changed to follow
suit.

Closes #59 