### PR TITLE
Show qualified type

### DIFF
--- a/src/inclusivity.jl
+++ b/src/inclusivity.jl
@@ -40,11 +40,11 @@ Base.isopen(x::Inclusivity) = !(first(x) || last(x))
 
 Base.isless(a::Inclusivity, b::Inclusivity) = isless(convert(Int, a), convert(Int, b))
 
-function Base.show(io::IO, x::Inclusivity)
+function Base.show(io::IO, x::T) where T <: Inclusivity
     if get(io, :compact, false)
         print(io, x)
     else
-        print(io, "Inclusivity($(x.first), $(x.last))")
+        print(io, "$T($(x.first), $(x.last))")
     end
 end
 

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -131,11 +131,11 @@ Compat.Dates.DateTime(interval::Interval{DateTime}) = convert(DateTime, interval
 
 ##### DISPLAY #####
 
-function Base.show(io::IO, interval::Interval{T}) where T
+function Base.show(io::IO, interval::T) where T <: Interval
     if get(io, :compact, false)
         print(io, interval)
     else
-        print(io, "Interval{$T}(")
+        print(io, "$T(")
         show(io, interval.first)
         print(io, ", ")
         show(io, interval.last)


### PR DESCRIPTION
Previously:
```julia
julia> import Intervals

julia> Intervals.Interval(1,2)
Interval{Int64}(1, 2, Inclusivity(true, true))

julia> Interval{Int64}(1, 2, Inclusivity(true, true))
ERROR: UndefVarError: Interval not defined
Stacktrace:
 [1] top-level scope at none:0
```
PR:
```julia
julia> import Intervals

julia> Intervals.Interval(1,2)
Intervals.Interval{Int64}(1, 2, Intervals.Inclusivity(true, true))

julia> Intervals.Interval{Int64}(1, 2, Intervals.Inclusivity(true, true))
Intervals.Interval{Int64}(1, 2, Intervals.Inclusivity(true, true))
```