### PR TITLE
specify compat for RecipeBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
+RecipesBase = "0.8, 1"
 TimeZones = "0.7, 0.8, 0.9, 0.10, 0.11, 1"
 julia = "1"
 


### PR DESCRIPTION
Follow up to #82  so I can tag release.
Got ot upper bound the versions.

I tested with 0.8 and 1.0
(interestingly TimeZones.jl is not compatible with 1.0 will make follow up for that,
but its incompatiability doesn't affect Intervals.jl)