### PR TITLE
Overload timezone

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Intervals"
 uuid = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Intervals.jl
+++ b/src/Intervals.jl
@@ -8,6 +8,7 @@ using TimeZones
 using Dates: AbstractDateTime, value, coarserperiod
 
 import Base: ⊆, ⊇, ⊈, ⊉, union, union!, merge
+import TimeZones: astimezone, timezone
 
 abstract type AbstractInterval{T} end
 

--- a/src/Intervals.jl
+++ b/src/Intervals.jl
@@ -8,7 +8,6 @@ using TimeZones
 using Dates: AbstractDateTime, value, coarserperiod
 
 import Base: ⊆, ⊇, ⊈, ⊉, union, union!, merge
-import TimeZones: astimezone, timezone
 
 abstract type AbstractInterval{T} end
 

--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -1,5 +1,3 @@
-import TimeZones: astimezone
-
 """
     AnchoredInterval{P, T}(anchor::T, [inclusivity::Inclusivity]) where {P, T} -> AnchoredInterval{P, T}
     AnchoredInterval{P, T}(anchor::T, [closed_left::Bool, closed_right::Bool]) where {P, T} -> AnchoredInterval{P, T}
@@ -284,3 +282,5 @@ canonicalize(target_type::Type{P}, p::P) where P <: Period = p
 function astimezone(i::AnchoredInterval{P, ZonedDateTime}, tz::TimeZone) where P
     return AnchoredInterval{P, ZonedDateTime}(astimezone(anchor(i), tz), inclusivity(i))
 end
+
+timezone(i::AnchoredInterval{P, ZonedDateTime}) where P = timezone(anchor(i))

--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -279,8 +279,8 @@ canonicalize(target_type::Type{P}, p::P) where P <: Period = p
 
 ##### TIME ZONES #####
 
-function astimezone(i::AnchoredInterval{P, ZonedDateTime}, tz::TimeZone) where P
+function TimeZones.astimezone(i::AnchoredInterval{P, ZonedDateTime}, tz::TimeZone) where P
     return AnchoredInterval{P, ZonedDateTime}(astimezone(anchor(i), tz), inclusivity(i))
 end
 
-timezone(i::AnchoredInterval{P, ZonedDateTime}) where P = timezone(anchor(i))
+TimeZones.timezone(i::AnchoredInterval{P, ZonedDateTime}) where P = timezone(anchor(i))

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -348,6 +348,8 @@ function TimeZones.astimezone(i::Interval{ZonedDateTime}, tz::TimeZone)
 end
 
 function TimeZones.timezone(i::Interval{ZonedDateTime})
-    timezone(first(i)) == timezone(last(i)) && return timezone(first(i))
-    throw(ArgumentError("Interval $i contains mixed timezones."))
+    if timezone(first(i)) != timezone(last(i))
+        throw(ArgumentError("Interval $i contains mixed timezones."))
+    end
+    return timezone(first(i))
 end

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -346,3 +346,5 @@ end
 function TimeZones.astimezone(i::Interval{ZonedDateTime}, tz::TimeZone)
     return Interval(astimezone(first(i), tz), astimezone(last(i), tz), inclusivity(i))
 end
+
+timezone(i::Interval{ZonedDateTime}) = timezone(first(i))

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -347,4 +347,7 @@ function TimeZones.astimezone(i::Interval{ZonedDateTime}, tz::TimeZone)
     return Interval(astimezone(first(i), tz), astimezone(last(i), tz), inclusivity(i))
 end
 
-timezone(i::Interval{ZonedDateTime}) = timezone(first(i))
+function timezone(i::Interval{ZonedDateTime})
+    timezone(first(i)) == timezone(last(i)) && return timezone(first(i))
+    throw(ArgumentError("Interval $i contains mixed timezones."))
+end

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -347,7 +347,7 @@ function TimeZones.astimezone(i::Interval{ZonedDateTime}, tz::TimeZone)
     return Interval(astimezone(first(i), tz), astimezone(last(i), tz), inclusivity(i))
 end
 
-function timezone(i::Interval{ZonedDateTime})
+function TimeZones.timezone(i::Interval{ZonedDateTime})
     timezone(first(i)) == timezone(last(i)) && return timezone(first(i))
     throw(ArgumentError("Interval $i contains mixed timezones."))
 end

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -640,4 +640,10 @@ using Intervals: canonicalize
             end
         end
     end
+
+    @testset "timezone" begin
+        zdt = ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg")
+        ai = AnchoredInterval{Day(1)}(zdt)
+        @test timezone(ai) == tz"America/Winnipeg"
+    end
 end

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -513,10 +513,17 @@
     end
 
     @testset "timezone" begin
-        zdt1 = ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg")
-        zdt2 = ZonedDateTime(2016, 8, 11, 21, tz"America/Winnipeg")
-        i = Interval(zdt1, zdt2)
-        @test timezone(i) == tz"America/Winnipeg"
+        @testset "basic" begin
+            zdt1 = ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg")
+            zdt2 = ZonedDateTime(2016, 8, 11, 21, tz"America/Winnipeg")
+            @test timezone(Interval(zdt1, zdt2)) == tz"America/Winnipeg"
+        end
+
+        @testset "multiple timezones" begin
+            zdt1 = ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg")
+            zdt2 = ZonedDateTime(2016, 8, 11, 21, tz"Europe/London")
+            @test_throws ArgumentError timezone(Interval(zdt1, zdt2))
+        end
     end
 
     @testset "merge" begin

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -512,6 +512,13 @@
         end
     end
 
+    @testset "timezone" begin
+        zdt1 = ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg")
+        zdt2 = ZonedDateTime(2016, 8, 11, 21, tz"America/Winnipeg")
+        i = Interval(zdt1, zdt2)
+        @test timezone(i) == tz"America/Winnipeg"
+    end
+
     @testset "merge" begin
         a = Interval(-100, -1)
         b = Interval(-3, 10)


### PR DESCRIPTION
So we can extract the timezone directly from the `Interval`

```julia
TimeZones.timezone(x::Interval{ZonedDateTime}) = timezone(first(x))
TimeZones.timezone(x::AnchoredInterval{P, ZonedDateTime}) where P = timezone(anchor(x))
```