### PR TITLE
Include plotting dependencies later

### DIFF
--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -1,3 +1,7 @@
+# Keeping these dependencies separate as the are slow to load
+using Plots
+using VisualRegressionTests
+
 @testset "plotting" begin
     possible_inclusivities = Iterators.product((true, false), (true, false))
     @testset "Interval{Float64} with inclusivity=$inc" for inc in possible_inclusivities

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,7 @@
 using Dates
-using Plots
 using Intervals
-using TimeZones
 using Test
-using VisualRegressionTests
-
-
+using TimeZones
 
 @testset "Intervals" begin
     include("inclusivity.jl")


### PR DESCRIPTION
Reduces the time-to-failure. Previously it would take 43 seconds to reach the end of the comparisons tests where now it only takes 22 seconds.