### PR TITLE
Deprecate reordering of Interval endpoints

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -60,6 +60,14 @@ struct Interval{T, L <: Bound, R <: Bound} <: AbstractInterval{T,L,R}
         f, l, left_bound, right_bound = if f ≤ l
             f, l, L, R
         elseif l ≤ f
+            # Note: Including the full stacktrace in this deprecation warning as most calls
+            # to this inner constructor will be from other constructors.
+            Base.depwarn(
+                "Constructing an `Interval{T,X,Y}(x, y)` " *
+                "where `x > y` is deprecated, use `Interval{T,Y,X}(y, x)` instead." *
+                sprint(Base.show_backtrace, stacktrace()),
+                :Interval,
+            )
             l, f, R, L
         else
             throw(ArgumentError("Unable to determine an ordering between: $f and $l"))

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -41,7 +41,6 @@ isinf(::TimeType) = false
             @test Interval(a, b) == Interval{T, Closed, Closed}(a, b)
             @test Interval{T}(a, b) == Interval{T, Closed, Closed}(a, b)
             @test Interval{Open, Closed}(a, b) == Interval{T, Open, Closed}(a, b)
-            @test Interval{Closed, Open}(b, a) == Interval{T, Open, Closed}(a, b)
             @test Interval(LeftEndpoint{Closed}(a), RightEndpoint{Closed}(b)) ==
                 Interval{T, Closed, Closed}(a, b)
 


### PR DESCRIPTION
Adds deprecation for: https://github.com/invenia/Intervals.jl/issues/57