### PR TITLE
Support intervals endpoints using infinity

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -85,11 +85,13 @@ Interval(interval::AbstractInterval) = convert(Interval, interval)
 Interval{T}(interval::AbstractInterval) where T = convert(Interval{T}, interval)
 
 # Endpoint constructors
-function Interval{T}(left::LeftEndpoint{T}, right::RightEndpoint{T}) where T
-    Interval{T}(left.endpoint, right.endpoint, left.included, right.included)
+function Interval{T}(left::LeftEndpoint, right::RightEndpoint) where T
+    Interval{T}(T(left.endpoint), T(right.endpoint), left.included, right.included)
 end
 
-Interval(left::LeftEndpoint{T}, right::RightEndpoint{T}) where T = Interval{T}(left, right)
+function Interval(left::LeftEndpoint{S}, right::RightEndpoint{T}) where {S, T}
+    Interval{promote_type(S, T)}(left, right)
+end
 
 # Empty Intervals
 Interval{T}() where T = Interval{T}(zero(T), zero(T), Inclusivity(false, false))

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -279,6 +279,14 @@ function Base.intersect(a::AbstractInterval{T}, b::AbstractInterval{T}) where T
     return Interval{T}(left, right)
 end
 
+function Base.intersect(a::AbstractInterval{S}, b::AbstractInterval{T}) where {S, T}
+    !overlaps(a, b) && return Interval{promote_type(S, T)}()
+    left = max(LeftEndpoint(a), LeftEndpoint(b))
+    right = min(RightEndpoint(a), RightEndpoint(b))
+
+    return Interval(left, right)
+end
+
 # There is power in a union.
 """
     union(intervals::AbstractVector{<:AbstractInterval})

--- a/test/comparisons.jl
+++ b/test/comparisons.jl
@@ -1,4 +1,5 @@
 using Intervals: Ending, Beginning, overlaps, contiguous, RightEndpoint, LeftEndpoint
+using Base.Iterators: product
 
 function unique_paired_permutation(v::Vector{T}) where T
     results = Tuple{T, T}[]
@@ -13,436 +14,624 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
 @testset "comparisons: $A vs. $B" for (A, B) in unique_paired_permutation(INTERVAL_TYPES)
 
     # Compare two intervals which are non-overlapping:
-    # Visualization:
+    # Visualization of the finite case:
     #
     # [12]
     #     [45]
     @testset "non-overlapping" begin
-        earlier = convert(A, Interval(1, 2, true, true))
-        later = convert(B, Interval(4, 5, true, true))
+        test_intervals = product(
+            [
+                Interval(1, 2, true, true),
+                Interval(-Inf, 2, true, true),
+            ],
+            [
+                Interval(4, 5, true, true),
+                Interval(4, Inf, true, true),
+            ],
+        )
 
-        expected_superset = Interval(1, 5, true, true)
-        expected_overlap = Interval{Int}()
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test earlier != later
-        @test !isequal(earlier, later)
-        @test hash(earlier) != hash(later)
+            earlier = convert(A, a)
+            later = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(a), RightEndpoint(b))
+            expected_overlap = Interval{promote_type(eltype(a), eltype(b))}()
 
-        @test isless(earlier, later)
-        @test !isless(later, earlier)
+            @test earlier != later
+            @test !isequal(earlier, later)
+            @test hash(earlier) != hash(later)
 
-        @test earlier < later
-        @test !(later < earlier)
+            @test isless(earlier, later)
+            @test !isless(later, earlier)
 
-        @test earlier ≪ later
-        @test !(later ≪ earlier)
+            @test earlier < later
+            @test !(later < earlier)
 
-        @test !issubset(earlier, later)
-        @test !issubset(later, earlier)
+            @test earlier ≪ later
+            @test !(later ≪ earlier)
 
-        @test intersect(earlier, later) == expected_overlap
-        @test_throws ArgumentError merge(earlier, later)
-        @test union([earlier, later]) == [earlier, later]
-        @test !overlaps(earlier, later)
-        @test !contiguous(earlier, later)
-        @test superset([earlier, later]) == expected_superset
+            @test !issubset(earlier, later)
+            @test !issubset(later, earlier)
+
+            @test intersect(earlier, later) == expected_overlap
+            @test_throws ArgumentError merge(earlier, later)
+            @test union([earlier, later]) == [earlier, later]
+            @test !overlaps(earlier, later)
+            @test !contiguous(earlier, later)
+            @test superset([earlier, later]) == expected_superset
+        end
     end
 
     # Compare two intervals which "touch" but both intervals do not include that point:
-    # Visualization:
+    # Visualization of the finite case:
     #
     # (123)
     #   (345)
     @testset "touching open/open" begin
-        earlier = convert(A, Interval(1, 3, false, false))
-        later = convert(B, Interval(3, 5, false, false))
+        test_intervals = product(
+            [
+                Interval(1, 3, false, false),
+                Interval(-Inf, 3, false, false),
+            ],
+            [
+                Interval(3, 5, false, false),
+                Interval(3, Inf, false, false),
+            ],
+        )
 
-        expected_superset = Interval(1, 5, false, false)
-        expected_overlap = Interval{Int}()
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test earlier != later
-        @test !isequal(earlier, later)
-        @test hash(earlier) != hash(later)
+            earlier = convert(A, a)
+            later = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(a), RightEndpoint(b))
+            expected_overlap = Interval{promote_type(eltype(a), eltype(b))}()
 
-        @test isless(earlier, later)
-        @test !isless(later, earlier)
+            @test earlier != later
+            @test !isequal(earlier, later)
+            @test hash(earlier) != hash(later)
 
-        @test earlier < later
-        @test !(later < earlier)
+            @test isless(earlier, later)
+            @test !isless(later, earlier)
 
-        @test earlier ≪ later
-        @test !(later ≪ earlier)
+            @test earlier < later
+            @test !(later < earlier)
 
-        @test !issubset(earlier, later)
-        @test !issubset(later, earlier)
+            @test earlier ≪ later
+            @test !(later ≪ earlier)
 
-        @test intersect(earlier, later) == expected_overlap
-        @test_throws ArgumentError merge(earlier, later)
-        @test union([earlier, later]) == [earlier, later]
-        @test !overlaps(earlier, later)
-        @test !contiguous(earlier, later)
-        @test superset([earlier, later]) == expected_superset
+            @test !issubset(earlier, later)
+            @test !issubset(later, earlier)
+
+            @test intersect(earlier, later) == expected_overlap
+            @test_throws ArgumentError merge(earlier, later)
+            @test union([earlier, later]) == [earlier, later]
+            @test !overlaps(earlier, later)
+            @test !contiguous(earlier, later)
+            @test superset([earlier, later]) == expected_superset
+        end
     end
 
     # Compare two intervals which "touch" and the later interval includes that point:
-    # Visualization:
+    # Visualization of the finite case:
     #
     # (123)
     #   [345]
     @testset "touching open/closed" begin
-        earlier = convert(A, Interval(1, 3, false, false))
-        later = convert(B, Interval(3, 5, true, true))
+         test_intervals = product(
+            [
+                Interval(1, 3, false, false),
+                Interval(-Inf, 3, false, false),
+            ],
+            [
+                Interval(3, 5, true, true),
+                Interval(3, Inf, true, true),
+            ],
+        )
 
-        expected_superset = Interval(1, 5, false, true)
-        expected_overlap = Interval{Int}()
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test earlier != later
-        @test !isequal(earlier, later)
-        @test hash(earlier) != hash(later)
+            earlier = convert(A, a)
+            later = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(a), RightEndpoint(b))
+            expected_overlap = Interval{promote_type(eltype(a), eltype(b))}()
 
-        @test isless(earlier, later)
-        @test !isless(later, earlier)
+            @test earlier != later
+            @test !isequal(earlier, later)
+            @test hash(earlier) != hash(later)
 
-        @test earlier < later
-        @test !(later < earlier)
+            @test isless(earlier, later)
+            @test !isless(later, earlier)
 
-        @test earlier ≪ later
-        @test !(later ≪ earlier)
+            @test earlier < later
+            @test !(later < earlier)
 
-        @test !issubset(earlier, later)
-        @test !issubset(later, earlier)
+            @test earlier ≪ later
+            @test !(later ≪ earlier)
 
-        @test intersect(earlier, later) == expected_overlap
-        @test merge(earlier, later) == expected_superset
-        @test union([earlier, later]) == [expected_superset]
-        @test !overlaps(earlier, later)
-        @test contiguous(earlier, later)
-        @test superset([earlier, later]) == expected_superset
+            @test !issubset(earlier, later)
+            @test !issubset(later, earlier)
+
+            @test intersect(earlier, later) == expected_overlap
+            @test merge(earlier, later) == expected_superset
+            @test union([earlier, later]) == [expected_superset]
+            @test !overlaps(earlier, later)
+            @test contiguous(earlier, later)
+            @test superset([earlier, later]) == expected_superset
+        end
     end
 
     # Compare two intervals which "touch" and the earlier interval includes that point:
-    # Visualization:
+    # Visualization of the finite case:
     #
     # [123]
     #   (345)
     @testset "touching closed/open" begin
-        earlier = convert(A, Interval(1, 3, true, true))
-        later = convert(B, Interval(3, 5, false, false))
+        test_intervals = product(
+            [
+                Interval(1, 3, true, true),
+                Interval(-Inf, 3, true, true),
+            ],
+            [
+                Interval(3, 5, false, false),
+                Interval(3, Inf, false, false),
+            ],
+        )
 
-        expected_superset = Interval(1, 5, true, false)
-        expected_overlap = Interval{Int}()
+        @testset "$a vs $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test earlier != later
-        @test !isequal(earlier, later)
-        @test hash(earlier) != hash(later)
+            earlier = convert(A, a)
+            later = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(a), RightEndpoint(b))
+            expected_overlap = Interval{promote_type(eltype(a), eltype(b))}()
 
-        @test isless(earlier, later)
-        @test !isless(later, earlier)
+            @test earlier != later
+            @test !isequal(earlier, later)
+            @test hash(earlier) != hash(later)
 
-        @test earlier < later
-        @test !(later < earlier)
+            @test isless(earlier, later)
+            @test !isless(later, earlier)
 
-        @test earlier ≪ later
-        @test !(later ≪ earlier)
+            @test earlier < later
+            @test !(later < earlier)
 
-        @test !issubset(earlier, later)
-        @test !issubset(later, earlier)
+            @test earlier ≪ later
+            @test !(later ≪ earlier)
 
-        @test intersect(earlier, later) == expected_overlap
-        @test merge(earlier, later) == expected_superset
-        @test union([earlier, later]) == [expected_superset]
-        @test !overlaps(earlier, later)
-        @test contiguous(earlier, later)
-        @test superset([earlier, later]) == expected_superset
+            @test !issubset(earlier, later)
+            @test !issubset(later, earlier)
+
+            @test intersect(earlier, later) == expected_overlap
+            @test merge(earlier, later) == expected_superset
+            @test union([earlier, later]) == [expected_superset]
+            @test !overlaps(earlier, later)
+            @test contiguous(earlier, later)
+            @test superset([earlier, later]) == expected_superset
+        end
     end
 
     # Compare two intervals which "touch" and both intervals include that point:
-    # Visualization:
+    # Visualization of the finite case:
     #
     # [123]
     #   [345]
     @testset "touching closed/closed" begin
-        earlier = convert(A, Interval(1, 3, true, true))
-        later = convert(B, Interval(3, 5, true, true))
+        test_intervals = product(
+            [
+                Interval(1, 3, true, true),
+                Interval(-Inf, 3, true, true),
+            ],
+            [
+                Interval(3, 5, true, true),
+                Interval(3, Inf, true, true),
+            ],
+        )
 
-        expected_superset = Interval(1, 5, true, true)
-        expected_overlap = Interval(3, 3, true, true)
+        @testset "$a vs $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test earlier != later
-        @test !isequal(earlier, later)
-        @test hash(earlier) != hash(later)
+            earlier = convert(A, a)
+            later = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(a), RightEndpoint(b))
+            expected_overlap = Interval(last(a), first(b), true, true)
 
-        @test isless(earlier, later)
-        @test !isless(later, earlier)
+            @test earlier != later
+            @test !isequal(earlier, later)
+            @test hash(earlier) != hash(later)
 
-        @test earlier < later
-        @test !(later < earlier)
+            @test isless(earlier, later)
+            @test !isless(later, earlier)
 
-        @test !(earlier ≪ later)
-        @test !(later ≪ earlier)
+            @test earlier < later
+            @test !(later < earlier)
 
-        @test !issubset(earlier, later)
-        @test !issubset(later, earlier)
+            @test !(earlier ≪ later)
+            @test !(later ≪ earlier)
 
-        @test intersect(earlier, later) == expected_overlap
-        @test merge(earlier, later) == expected_superset
-        @test union([earlier, later]) == [expected_superset]
-        @test overlaps(earlier, later)
-        @test !contiguous(earlier, later)
-        @test superset([earlier, later]) == expected_superset
+            @test !issubset(earlier, later)
+            @test !issubset(later, earlier)
+
+            @test intersect(earlier, later) == expected_overlap
+            @test merge(earlier, later) == expected_superset
+            @test union([earlier, later]) == [expected_superset]
+            @test overlaps(earlier, later)
+            @test !contiguous(earlier, later)
+            @test superset([earlier, later]) == expected_superset
+        end
     end
 
     # Compare two intervals which overlap
-    # Visualization:
+    # Visualization of the finite case:
     #
     # [1234]
     #  [2345]
     @testset "overlapping" begin
-        earlier = convert(A, Interval(1, 4, true, true))
-        later = convert(B, Interval(2, 5, true, true))
+        test_intervals = product(
+            [
+                Interval(1, 4, true, true),
+                Interval(-Inf, 4, true, true),
+            ],
+            [
+                Interval(2, 5, true, true),
+                Interval(2, Inf, true, true),
+            ],
+        )
 
-        expected_superset = Interval(1, 5, true, true)
-        expected_overlap = Interval(2, 4, true, true)
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test earlier != later
-        @test !isequal(earlier, later)
-        @test hash(earlier) != hash(later)
+            earlier = convert(A, a)
+            later = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(a), RightEndpoint(b))
+            expected_overlap = Interval(LeftEndpoint(b), RightEndpoint(a))
 
-        @test isless(earlier, later)
-        @test !isless(later, earlier)
+            @test earlier != later
+            @test !isequal(earlier, later)
+            @test hash(earlier) != hash(later)
 
-        @test earlier < later
-        @test !(later < earlier)
+            @test isless(earlier, later)
+            @test !isless(later, earlier)
 
-        @test !(earlier ≪ later)
-        @test !(later ≪ earlier)
+            @test earlier < later
+            @test !(later < earlier)
 
-        @test !issubset(earlier, later)
-        @test !issubset(later, earlier)
+            @test !(earlier ≪ later)
+            @test !(later ≪ earlier)
 
-        @test intersect(earlier, later) == expected_overlap
-        @test merge(earlier, later) == expected_superset
-        @test union([earlier, later]) == [expected_superset]
-        @test overlaps(earlier, later)
-        @test !contiguous(earlier, later)
-        @test superset([earlier, later]) == expected_superset
+            @test !issubset(earlier, later)
+            @test !issubset(later, earlier)
+
+            @test intersect(earlier, later) == expected_overlap
+            @test merge(earlier, later) == expected_superset
+            @test union([earlier, later]) == [expected_superset]
+            @test overlaps(earlier, later)
+            @test !contiguous(earlier, later)
+            @test superset([earlier, later]) == expected_superset
+        end
     end
 
     @testset "equal ()/()" begin
-        a = convert(A, Interval(1, 5, false, false))
-        b = convert(B, Interval(1, 5, false, false))
+        test_intervals = (
+            [
+                Interval(l, u, false, false),
+                Interval(l, u, false, false),
+            ]
+            for (l, u) in product((1, -Inf), (5, Inf))
+        )
 
-        expected_superset = Interval(1, 5, false, false)
-        expected_overlap = Interval(1, 5, false, false)
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            A == AnchoredInterval{Ending} && !isfinite(last(a)) && continue
+            B == AnchoredInterval{Beginning} && !isfinite(first(b)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test a == b
-        @test isequal(a, b)
-        @test hash(a) == hash(b)
+            a = convert(A, a)
+            b = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(a), RightEndpoint(a))
+            expected_overlap = Interval(LeftEndpoint(b), RightEndpoint(b))
 
-        @test !isless(a, b)
-        @test !isless(a, b)
+            @test a == b
+            @test isequal(a, b)
+            @test hash(a) == hash(b)
 
-        @test !(a < b)
-        @test !(b < a)
+            @test !isless(a, b)
+            @test !isless(a, b)
 
-        @test !(a ≪ b)
-        @test !(b ≪ a)
+            @test !(a < b)
+            @test !(b < a)
 
-        @test issubset(a, b)
-        @test issubset(b, a)
+            @test !(a ≪ b)
+            @test !(b ≪ a)
 
-        @test intersect(a, b) == expected_overlap
-        @test merge(a, b) == expected_superset
-        @test union([a, b]) == [expected_superset]
-        @test overlaps(a, b)
-        @test !contiguous(a, b)
-        @test superset([a, b]) == expected_superset
+            @test issubset(a, b)
+            @test issubset(b, a)
+
+            @test intersect(a, b) == expected_overlap
+            @test merge(a, b) == expected_superset
+            @test union([a, b]) == [expected_superset]
+            @test overlaps(a, b)
+            @test !contiguous(a, b)
+            @test superset([a, b]) == expected_superset
+        end
     end
 
     @testset "equal [)/()" begin
-        a = convert(A, Interval(1, 5, true, false))
-        b = convert(B, Interval(1, 5, false, false))
+        test_intervals = (
+            [
+                Interval(l, u, true, false),
+                Interval(l, u, false, false),
+            ]
+            for (l, u) in product((1, -Inf), (5, Inf))
+        )
 
-        expected_superset = Interval(1, 5, true, false)
-        expected_overlap = Interval(1, 5, false, false)
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            A == AnchoredInterval{Ending} && !isfinite(last(a)) && continue
+            B == AnchoredInterval{Beginning} && !isfinite(first(b)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test a != b
-        @test !isequal(a, b)
-        @test hash(a) != hash(b)
+            a = convert(A, a)
+            b = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(a), RightEndpoint(a))
+            expected_overlap = Interval(LeftEndpoint(b), RightEndpoint(b))
 
-        @test isless(a, b)
-        @test !isless(b, a)
+            @test a != b
+            @test !isequal(a, b)
+            @test hash(a) != hash(b)
 
-        @test a < b
-        @test !(b < a)
+            @test isless(a, b)
+            @test !isless(b, a)
 
-        @test !(a ≪ b)
-        @test !(b ≪ a)
+            @test a < b
+            @test !(b < a)
 
-        @test !issubset(a, b)
-        @test issubset(b, a)
+            @test !(a ≪ b)
+            @test !(b ≪ a)
 
-        @test intersect(a, b) == expected_overlap
-        @test merge(a, b) == expected_superset
-        @test union([a, b]) == [expected_superset]
-        @test overlaps(a, b)
-        @test !contiguous(a, b)
-        @test superset([a, b]) == expected_superset
+            @test !issubset(a, b)
+            @test issubset(b, a)
+
+            @test intersect(a, b) == expected_overlap
+            @test merge(a, b) == expected_superset
+            @test union([a, b]) == [expected_superset]
+            @test overlaps(a, b)
+            @test !contiguous(a, b)
+            @test superset([a, b]) == expected_superset
+        end
     end
 
     @testset "equal (]/()" begin
-        a = convert(A, Interval(1, 5, false, true))
-        b = convert(B, Interval(1, 5, false, false))
+        test_intervals = (
+            [
+                Interval(l, u, false, true),
+                Interval(l, u, false, false),
+            ]
+            for (l, u) in product((1, -Inf), (5, Inf))
+        )
 
-        expected_superset = Interval(1, 5, false, true)
-        expected_overlap = Interval(1, 5, false, false)
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            A == AnchoredInterval{Ending} && !isfinite(last(a)) && continue
+            B == AnchoredInterval{Beginning} && !isfinite(first(b)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test a != b
-        @test !isequal(a, b)
-        @test hash(a) != hash(b)
+            a = convert(A, a)
+            b = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(a), RightEndpoint(a))
+            expected_overlap = Interval(LeftEndpoint(b), RightEndpoint(b))
 
-        @test !isless(a, b)
-        @test !isless(b, a)
+            @test a != b
+            @test !isequal(a, b)
+            @test hash(a) != hash(b)
 
-        @test !(a < b)
-        @test !(b < a)
+            @test !isless(a, b)
+            @test !isless(b, a)
 
-        @test !(a ≪ b)
-        @test !(b ≪ a)
+            @test !(a < b)
+            @test !(b < a)
 
-        @test !issubset(a, b)
-        @test issubset(b, a)
+            @test !(a ≪ b)
+            @test !(b ≪ a)
 
-        @test intersect(a, b) == expected_overlap
-        @test merge(a, b) == expected_superset
-        @test union([a, b]) == [expected_superset]
-        @test overlaps(a, b)
-        @test !contiguous(a, b)
-        @test superset([a, b]) == expected_superset
+            @test !issubset(a, b)
+            @test issubset(b, a)
+
+            @test intersect(a, b) == expected_overlap
+            @test merge(a, b) == expected_superset
+            @test union([a, b]) == [expected_superset]
+            @test overlaps(a, b)
+            @test !contiguous(a, b)
+            @test superset([a, b]) == expected_superset
+        end
     end
 
     @testset "equal []/()" begin
-        a = convert(A, Interval(1, 5, true, true))
-        b = convert(B, Interval(1, 5, false, false))
+        test_intervals = (
+            [
+                Interval(l, u, true, true),
+                Interval(l, u, false, false),
+            ]
+            for (l, u) in product((1, -Inf), (5, Inf))
+        )
 
-        expected_superset = Interval(1, 5, true, true)
-        expected_overlap = Interval(1, 5, false, false)
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            A == AnchoredInterval{Ending} && !isfinite(last(a)) && continue
+            B == AnchoredInterval{Beginning} && !isfinite(first(b)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test a != b
-        @test !isequal(a, b)
-        @test hash(a) != hash(b)
+            a = convert(A, a)
+            b = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(a), RightEndpoint(a))
+            expected_overlap = Interval(LeftEndpoint(b), RightEndpoint(b))
 
-        @test isless(a, b)
-        @test !isless(b, a)
+            @test a != b
+            @test !isequal(a, b)
+            @test hash(a) != hash(b)
 
-        @test a < b
-        @test !(b < a)
+            @test isless(a, b)
+            @test !isless(b, a)
 
-        @test !(a ≪ b)
-        @test !(b ≪ a)
+            @test a < b
+            @test !(b < a)
 
-        @test !issubset(a, b)
-        @test issubset(b, a)
+            @test !(a ≪ b)
+            @test !(b ≪ a)
 
-        @test intersect(a, b) == expected_overlap
-        @test merge(a, b) == expected_superset
-        @test union([a, b]) == [expected_superset]
-        @test overlaps(a, b)
-        @test !contiguous(a, b)
-        @test superset([a, b]) == expected_superset
+            @test !issubset(a, b)
+            @test issubset(b, a)
+
+            @test intersect(a, b) == expected_overlap
+            @test merge(a, b) == expected_superset
+            @test union([a, b]) == [expected_superset]
+            @test overlaps(a, b)
+            @test !contiguous(a, b)
+            @test superset([a, b]) == expected_superset
+        end
     end
 
     @testset "equal [)/[]" begin
-        a = convert(A, Interval(1, 5, true, false))
-        b = convert(B, Interval(1, 5, true, true))
+        test_intervals = (
+            [
+                Interval(l, u, true, false),
+                Interval(l, u, true, true),
+            ]
+            for (l, u) in product((1, -Inf), (5, Inf))
+        )
 
-        expected_superset = Interval(1, 5, true, true)
-        expected_overlap = Interval(1, 5, true, false)
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            A == AnchoredInterval{Ending} && !isfinite(last(a)) && continue
+            B == AnchoredInterval{Beginning} && !isfinite(first(b)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test a != b
-        @test !isequal(a, b)
-        @test hash(a) != hash(b)
+            a = convert(A, a)
+            b = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(b), RightEndpoint(b))
+            expected_overlap = Interval(LeftEndpoint(a), RightEndpoint(a))
 
-        @test !isless(a, b)
-        @test !isless(b, a)
+            @test a != b
+            @test !isequal(a, b)
+            @test hash(a) != hash(b)
 
-        @test !(a < b)
-        @test !(b < a)
+            @test !isless(a, b)
+            @test !isless(b, a)
 
-        @test !(a ≪ b)
-        @test !(b ≪ a)
+            @test !(a < b)
+            @test !(b < a)
 
-        @test issubset(a, b)
-        @test !issubset(b, a)
+            @test !(a ≪ b)
+            @test !(b ≪ a)
 
-        @test intersect(a, b) == expected_overlap
-        @test merge(a, b) == expected_superset
-        @test union([a, b]) == [expected_superset]
-        @test overlaps(a, b)
-        @test !contiguous(a, b)
-        @test superset([a, b]) == expected_superset
+            @test issubset(a, b)
+            @test !issubset(b, a)
+
+            @test intersect(a, b) == expected_overlap
+            @test merge(a, b) == expected_superset
+            @test union([a, b]) == [expected_superset]
+            @test overlaps(a, b)
+            @test !contiguous(a, b)
+            @test superset([a, b]) == expected_superset
+        end
     end
 
     @testset "equal (]/[]" begin
-        a = convert(A, Interval(1, 5, false, true))
-        b = convert(B, Interval(1, 5, true, true))
+        test_intervals = (
+            [
+                Interval(l, u, false, true),
+                Interval(l, u, true, true),
+            ]
+            for (l, u) in product((1, -Inf), (5, Inf))
+        )
 
-        expected_superset = Interval(1, 5, true, true)
-        expected_overlap = Interval(1, 5, false, true)
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            A == AnchoredInterval{Ending} && !isfinite(last(a)) && continue
+            B == AnchoredInterval{Beginning} && !isfinite(first(b)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test a != b
-        @test !isequal(a, b)
-        @test hash(a) != hash(b)
+            a = convert(A, a)
+            b = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(b), RightEndpoint(b))
+            expected_overlap = Interval(LeftEndpoint(a), RightEndpoint(a))
 
-        @test !isless(a, b)
-        @test isless(b, a)
+            @test a != b
+            @test !isequal(a, b)
+            @test hash(a) != hash(b)
 
-        @test !(a < b)
-        @test b < a
+            @test !isless(a, b)
+            @test isless(b, a)
 
-        @test !(a ≪ b)
-        @test !(b ≪ a)
+            @test !(a < b)
+            @test b < a
 
-        @test issubset(a, b)
-        @test !issubset(b, a)
+            @test !(a ≪ b)
+            @test !(b ≪ a)
 
-        @test intersect(a, b) == expected_overlap
-        @test merge(a, b) == expected_superset
-        @test union([a, b]) == [expected_superset]
-        @test overlaps(a, b)
-        @test !contiguous(a, b)
-        @test superset([a, b]) == expected_superset
+            @test issubset(a, b)
+            @test !issubset(b, a)
+
+            @test intersect(a, b) == expected_overlap
+            @test merge(a, b) == expected_superset
+            @test union([a, b]) == [expected_superset]
+            @test overlaps(a, b)
+            @test !contiguous(a, b)
+            @test superset([a, b]) == expected_superset
+        end
     end
 
     @testset "equal []/[]" begin
-        a = convert(A, Interval(1, 5, true, true))
-        b = convert(B, Interval(1, 5, true, true))
+        test_intervals = (
+            [
+                Interval(l, u, true, true),
+                Interval(l, u, true, true),
+            ]
+            for (l, u) in product((1, -Inf), (5, Inf))
+        )
 
-        expected_superset = Interval(1, 5, true, true)
-        expected_overlap = Interval(1, 5, true, true)
+        @testset "$a vs. $b" for (a, b) in test_intervals
+            A == AnchoredInterval{Beginning} && !isfinite(first(a)) && continue
+            A == AnchoredInterval{Ending} && !isfinite(last(a)) && continue
+            B == AnchoredInterval{Beginning} && !isfinite(first(b)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test a == b
-        @test isequal(a, b)
-        @test hash(a) == hash(b)
+            a = convert(A, a)
+            b = convert(B, b)
+            expected_superset = Interval(LeftEndpoint(b), RightEndpoint(b))
+            expected_overlap = Interval(LeftEndpoint(a), RightEndpoint(a))
 
-        @test !isless(a, b)
-        @test !isless(b, a)
+            @test a == b
+            @test isequal(a, b)
+            @test hash(a) == hash(b)
 
-        @test !(a < b)
-        @test !(b < a)
+            @test !isless(a, b)
+            @test !isless(b, a)
 
-        @test !(a ≪ b)
-        @test !(b ≪ a)
+            @test !(a < b)
+            @test !(b < a)
 
-        @test issubset(a, b)
-        @test issubset(b, a)
+            @test !(a ≪ b)
+            @test !(b ≪ a)
 
-        @test intersect(a, b) == expected_overlap
-        @test merge(a, b) == expected_superset
-        @test union([a, b]) == [expected_superset]
-        @test overlaps(a, b)
-        @test !contiguous(a, b)
-        @test superset([a, b]) == expected_superset
+            @test issubset(a, b)
+            @test issubset(b, a)
+
+            @test intersect(a, b) == expected_overlap
+            @test merge(a, b) == expected_superset
+            @test union([a, b]) == [expected_superset]
+            @test overlaps(a, b)
+            @test !contiguous(a, b)
+            @test superset([a, b]) == expected_superset
+        end
     end
 
     @testset "equal -0.0/0.0" begin
@@ -450,7 +639,6 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         if Set((A, B)) != Set((AnchoredInterval{Ending}, AnchoredInterval{Beginning}))
             a = convert(A, Interval(0.0, -0.0))
             b = convert(B, Interval(-0.0, 0.0))
-
             expected_superset = Interval(0.0, 0.0)
             expected_overlap = Interval(0.0, 0.0)
 
@@ -481,38 +669,54 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
     end
 
     # Compare two intervals where the first interval is contained by the second
-    # Visualization:
+    # Visualization of the finite case:
     #
     #  [234]
     # [12345]
     @testset "containing" begin
-        smaller = convert(A, Interval(2, 4, true, true))
-        larger = convert(B, Interval(1, 5, true, true))
+        test_intervals = product(
+            [
+                Interval(2, 4, true, true),
+            ],
+            [
+                Interval(1, 5, true, true),
+                Interval(1, Inf, true, true),
+                Interval(-Inf, 5, true, true),
+                Interval(-Inf, Inf, true, true),
+            ],
+        )
 
-        expected_superset = Interval(larger)
-        expected_overlap = Interval(smaller)
+        @testset "$a vs $b" for (a, b) in test_intervals
+            B == AnchoredInterval{Beginning} && !isfinite(first(b)) && continue
+            B == AnchoredInterval{Ending} && !isfinite(last(b)) && continue
 
-        @test smaller != larger
-        @test !isequal(smaller, larger)
-        @test hash(smaller) != hash(larger)
+            smaller = convert(A, a)
+            larger = convert(B, b)
+            expected_superset = Interval(larger)
+            expected_overlap = Interval(smaller)
 
-        @test !isless(smaller, larger)
-        @test isless(larger, smaller)
+            @test smaller != larger
+            @test !isequal(smaller, larger)
+            @test hash(smaller) != hash(larger)
 
-        @test !(smaller < larger)
-        @test larger < smaller
+            @test !isless(smaller, larger)
+            @test isless(larger, smaller)
 
-        @test !(smaller ≪ larger)
-        @test !(larger ≪ smaller)
+            @test !(smaller < larger)
+            @test larger < smaller
 
-        @test issubset(smaller, larger)
-        @test !issubset(larger, smaller)
+            @test !(smaller ≪ larger)
+            @test !(larger ≪ smaller)
 
-        @test intersect(smaller, larger) == expected_overlap
-        @test merge(smaller, larger) == expected_superset
-        @test union([smaller, larger]) == [expected_superset]
-        @test overlaps(smaller, larger)
-        @test !contiguous(smaller, larger)
-        @test superset([smaller, larger]) == expected_superset
+            @test issubset(smaller, larger)
+            @test !issubset(larger, smaller)
+
+            @test intersect(smaller, larger) == expected_overlap
+            @test merge(smaller, larger) == expected_superset
+            @test union([smaller, larger]) == [expected_superset]
+            @test overlaps(smaller, larger)
+            @test !contiguous(smaller, larger)
+            @test superset([smaller, larger]) == expected_superset
+        end
     end
 end

--- a/test/comparisons.jl
+++ b/test/comparisons.jl
@@ -21,6 +21,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         earlier = convert(A, Interval(1, 2, true, true))
         later = convert(B, Interval(4, 5, true, true))
 
+        expected_superset = Interval(1, 5, true, true)
+        expected_overlap = Interval{Int}()
+
         @test earlier != later
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
@@ -37,12 +40,12 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
 
-        @test isempty(intersect(earlier, later))
+        @test intersect(earlier, later) == expected_overlap
         @test_throws ArgumentError merge(earlier, later)
         @test union([earlier, later]) == [earlier, later]
         @test !overlaps(earlier, later)
         @test !contiguous(earlier, later)
-        @test superset([earlier, later]) == Interval(1, 5, true, true)
+        @test superset([earlier, later]) == expected_superset
     end
 
     # Compare two intervals which "touch" but both intervals do not include that point:
@@ -54,6 +57,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         earlier = convert(A, Interval(1, 3, false, false))
         later = convert(B, Interval(3, 5, false, false))
 
+        expected_superset = Interval(1, 5, false, false)
+        expected_overlap = Interval{Int}()
+
         @test earlier != later
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
@@ -70,12 +76,12 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
 
-        @test isempty(intersect(earlier, later))
+        @test intersect(earlier, later) == expected_overlap
         @test_throws ArgumentError merge(earlier, later)
         @test union([earlier, later]) == [earlier, later]
         @test !overlaps(earlier, later)
         @test !contiguous(earlier, later)
-        @test superset([earlier, later]) == Interval(1, 5, false, false)
+        @test superset([earlier, later]) == expected_superset
     end
 
     # Compare two intervals which "touch" and the later interval includes that point:
@@ -87,6 +93,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         earlier = convert(A, Interval(1, 3, false, false))
         later = convert(B, Interval(3, 5, true, true))
 
+        expected_superset = Interval(1, 5, false, true)
+        expected_overlap = Interval{Int}()
+
         @test earlier != later
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
@@ -103,12 +112,12 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
 
-        @test isempty(intersect(earlier, later))
-        @test merge(earlier, later) == Interval(1, 5, false, true)
-        @test union([earlier, later]) == [Interval(1, 5, false, true)]
+        @test intersect(earlier, later) == expected_overlap
+        @test merge(earlier, later) == expected_superset
+        @test union([earlier, later]) == [expected_superset]
         @test !overlaps(earlier, later)
         @test contiguous(earlier, later)
-        @test superset([earlier, later]) == Interval(1, 5, false, true)
+        @test superset([earlier, later]) == expected_superset
     end
 
     # Compare two intervals which "touch" and the earlier interval includes that point:
@@ -120,6 +129,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         earlier = convert(A, Interval(1, 3, true, true))
         later = convert(B, Interval(3, 5, false, false))
 
+        expected_superset = Interval(1, 5, true, false)
+        expected_overlap = Interval{Int}()
+
         @test earlier != later
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
@@ -136,12 +148,12 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
 
-        @test isempty(intersect(earlier, later))
-        @test merge(earlier, later) == Interval(1, 5, true, false)
-        @test union([earlier, later]) == [Interval(1, 5, true, false)]
+        @test intersect(earlier, later) == expected_overlap
+        @test merge(earlier, later) == expected_superset
+        @test union([earlier, later]) == [expected_superset]
         @test !overlaps(earlier, later)
         @test contiguous(earlier, later)
-        @test superset([earlier, later]) == Interval(1, 5, true, false)
+        @test superset([earlier, later]) == expected_superset
     end
 
     # Compare two intervals which "touch" and both intervals include that point:
@@ -153,6 +165,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         earlier = convert(A, Interval(1, 3, true, true))
         later = convert(B, Interval(3, 5, true, true))
 
+        expected_superset = Interval(1, 5, true, true)
+        expected_overlap = Interval(3, 3, true, true)
+
         @test earlier != later
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
@@ -169,12 +184,12 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
 
-        @test intersect(earlier, later) == Interval(3, 3, true, true)
-        @test merge(earlier, later) == Interval(1, 5, true, true)
-        @test union([earlier, later]) == [Interval(1, 5, true, true)]
+        @test intersect(earlier, later) == expected_overlap
+        @test merge(earlier, later) == expected_superset
+        @test union([earlier, later]) == [expected_superset]
         @test overlaps(earlier, later)
         @test !contiguous(earlier, later)
-        @test superset([earlier, later]) == Interval(1, 5, true, true)
+        @test superset([earlier, later]) == expected_superset
     end
 
     # Compare two intervals which overlap
@@ -186,6 +201,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         earlier = convert(A, Interval(1, 4, true, true))
         later = convert(B, Interval(2, 5, true, true))
 
+        expected_superset = Interval(1, 5, true, true)
+        expected_overlap = Interval(2, 4, true, true)
+
         @test earlier != later
         @test !isequal(earlier, later)
         @test hash(earlier) != hash(later)
@@ -202,17 +220,20 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !issubset(earlier, later)
         @test !issubset(later, earlier)
 
-        @test intersect(earlier, later) == Interval(2, 4, true, true)
-        @test merge(earlier, later) == Interval(1, 5, true, true)
-        @test union([earlier, later]) == [Interval(1, 5, true, true)]
+        @test intersect(earlier, later) == expected_overlap
+        @test merge(earlier, later) == expected_superset
+        @test union([earlier, later]) == [expected_superset]
         @test overlaps(earlier, later)
         @test !contiguous(earlier, later)
-        @test superset([earlier, later]) == Interval(1, 5, true, true)
+        @test superset([earlier, later]) == expected_superset
     end
 
     @testset "equal ()/()" begin
         a = convert(A, Interval(1, 5, false, false))
         b = convert(B, Interval(1, 5, false, false))
+
+        expected_superset = Interval(1, 5, false, false)
+        expected_overlap = Interval(1, 5, false, false)
 
         @test a == b
         @test isequal(a, b)
@@ -230,17 +251,20 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test issubset(a, b)
         @test issubset(b, a)
 
-        @test intersect(a, b) == Interval(1, 5, false, false)
-        @test merge(a, b) == Interval(1, 5, false, false)
-        @test union([a, b]) == [Interval(1, 5, false, false)]
+        @test intersect(a, b) == expected_overlap
+        @test merge(a, b) == expected_superset
+        @test union([a, b]) == [expected_superset]
         @test overlaps(a, b)
         @test !contiguous(a, b)
-        @test superset([a, b]) == Interval(1, 5, false, false)
+        @test superset([a, b]) == expected_superset
     end
 
     @testset "equal [)/()" begin
         a = convert(A, Interval(1, 5, true, false))
         b = convert(B, Interval(1, 5, false, false))
+
+        expected_superset = Interval(1, 5, true, false)
+        expected_overlap = Interval(1, 5, false, false)
 
         @test a != b
         @test !isequal(a, b)
@@ -258,17 +282,20 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !issubset(a, b)
         @test issubset(b, a)
 
-        @test intersect(a, b) == Interval(1, 5, false, false)
-        @test merge(a, b) == Interval(1, 5, true, false)
-        @test union([a, b]) == [Interval(1, 5, true, false)]
+        @test intersect(a, b) == expected_overlap
+        @test merge(a, b) == expected_superset
+        @test union([a, b]) == [expected_superset]
         @test overlaps(a, b)
         @test !contiguous(a, b)
-        @test superset([a, b]) == Interval(1, 5, true, false)
+        @test superset([a, b]) == expected_superset
     end
 
     @testset "equal (]/()" begin
         a = convert(A, Interval(1, 5, false, true))
         b = convert(B, Interval(1, 5, false, false))
+
+        expected_superset = Interval(1, 5, false, true)
+        expected_overlap = Interval(1, 5, false, false)
 
         @test a != b
         @test !isequal(a, b)
@@ -286,17 +313,20 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !issubset(a, b)
         @test issubset(b, a)
 
-        @test intersect(a, b) == Interval(1, 5, false, false)
-        @test merge(a, b) == Interval(1, 5, false, true)
-        @test union([a, b]) == [Interval(1, 5, false, true)]
+        @test intersect(a, b) == expected_overlap
+        @test merge(a, b) == expected_superset
+        @test union([a, b]) == [expected_superset]
         @test overlaps(a, b)
         @test !contiguous(a, b)
-        @test superset([a, b]) == Interval(1, 5, false, true)
+        @test superset([a, b]) == expected_superset
     end
 
     @testset "equal []/()" begin
         a = convert(A, Interval(1, 5, true, true))
         b = convert(B, Interval(1, 5, false, false))
+
+        expected_superset = Interval(1, 5, true, true)
+        expected_overlap = Interval(1, 5, false, false)
 
         @test a != b
         @test !isequal(a, b)
@@ -314,17 +344,20 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test !issubset(a, b)
         @test issubset(b, a)
 
-        @test intersect(a, b) == Interval(1, 5, false, false)
-        @test merge(a, b) == Interval(1, 5, true, true)
-        @test union([a, b]) == [Interval(1, 5, true, true)]
+        @test intersect(a, b) == expected_overlap
+        @test merge(a, b) == expected_superset
+        @test union([a, b]) == [expected_superset]
         @test overlaps(a, b)
         @test !contiguous(a, b)
-        @test superset([a, b]) == Interval(1, 5, true, true)
+        @test superset([a, b]) == expected_superset
     end
 
     @testset "equal [)/[]" begin
         a = convert(A, Interval(1, 5, true, false))
         b = convert(B, Interval(1, 5, true, true))
+
+        expected_superset = Interval(1, 5, true, true)
+        expected_overlap = Interval(1, 5, true, false)
 
         @test a != b
         @test !isequal(a, b)
@@ -342,17 +375,20 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test issubset(a, b)
         @test !issubset(b, a)
 
-        @test intersect(a, b) == Interval(1, 5, true, false)
-        @test merge(a, b) == Interval(1, 5, true, true)
-        @test union([a, b]) == [Interval(1, 5, true, true)]
+        @test intersect(a, b) == expected_overlap
+        @test merge(a, b) == expected_superset
+        @test union([a, b]) == [expected_superset]
         @test overlaps(a, b)
         @test !contiguous(a, b)
-        @test superset([a, b]) == Interval(1, 5, true, true)
+        @test superset([a, b]) == expected_superset
     end
 
     @testset "equal (]/[]" begin
         a = convert(A, Interval(1, 5, false, true))
         b = convert(B, Interval(1, 5, true, true))
+
+        expected_superset = Interval(1, 5, true, true)
+        expected_overlap = Interval(1, 5, false, true)
 
         @test a != b
         @test !isequal(a, b)
@@ -370,17 +406,20 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test issubset(a, b)
         @test !issubset(b, a)
 
-        @test intersect(a, b) == Interval(1, 5, false, true)
-        @test merge(a, b) == Interval(1, 5, true, true)
-        @test union([a, b]) == [Interval(1, 5, true, true)]
+        @test intersect(a, b) == expected_overlap
+        @test merge(a, b) == expected_superset
+        @test union([a, b]) == [expected_superset]
         @test overlaps(a, b)
         @test !contiguous(a, b)
-        @test superset([a, b]) == Interval(1, 5, true, true)
+        @test superset([a, b]) == expected_superset
     end
 
     @testset "equal []/[]" begin
         a = convert(A, Interval(1, 5, true, true))
         b = convert(B, Interval(1, 5, true, true))
+
+        expected_superset = Interval(1, 5, true, true)
+        expected_overlap = Interval(1, 5, true, true)
 
         @test a == b
         @test isequal(a, b)
@@ -398,12 +437,12 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test issubset(a, b)
         @test issubset(b, a)
 
-        @test intersect(a, b) == Interval(1, 5, true, true)
-        @test merge(a, b) == Interval(1, 5, true, true)
-        @test union([a, b]) == [Interval(1, 5, true, true)]
+        @test intersect(a, b) == expected_overlap
+        @test merge(a, b) == expected_superset
+        @test union([a, b]) == [expected_superset]
         @test overlaps(a, b)
         @test !contiguous(a, b)
-        @test superset([a, b]) == Interval(1, 5, true, true)
+        @test superset([a, b]) == expected_superset
     end
 
     @testset "equal -0.0/0.0" begin
@@ -411,6 +450,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         if Set((A, B)) != Set((AnchoredInterval{Ending}, AnchoredInterval{Beginning}))
             a = convert(A, Interval(0.0, -0.0))
             b = convert(B, Interval(-0.0, 0.0))
+
+            expected_superset = Interval(0.0, 0.0)
+            expected_overlap = Interval(0.0, 0.0)
 
             @test a == b
             @test !isequal(a, b)
@@ -429,14 +471,15 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
             @test issubset(a, b)
             @test issubset(b, a)
 
-            @test intersect(a, b) == Interval(0.0, 0.0)
-            @test merge(a, b) == Interval(0.0, 0.0)
-            @test union([a, b]) == [Interval(0.0, 0.0)]
+            @test intersect(a, b) == expected_overlap
+            @test merge(a, b) == expected_superset
+            @test union([a, b]) == [expected_superset]
             @test overlaps(a, b)
             @test !contiguous(a, b)
-            @test superset([a, b]) == Interval(0.0, 0.0)
+            @test superset([a, b]) == expected_superset
         end
     end
+
     # Compare two intervals where the first interval is contained by the second
     # Visualization:
     #
@@ -445,6 +488,9 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
     @testset "containing" begin
         smaller = convert(A, Interval(2, 4, true, true))
         larger = convert(B, Interval(1, 5, true, true))
+
+        expected_superset = Interval(larger)
+        expected_overlap = Interval(smaller)
 
         @test smaller != larger
         @test !isequal(smaller, larger)
@@ -462,11 +508,11 @@ const INTERVAL_TYPES = [Interval, AnchoredInterval{Ending}, AnchoredInterval{Beg
         @test issubset(smaller, larger)
         @test !issubset(larger, smaller)
 
-        @test intersect(smaller, larger) == Interval(smaller)
-        @test merge(smaller, larger) == Interval(larger)
-        @test union([smaller, larger]) == [Interval(larger)]
+        @test intersect(smaller, larger) == expected_overlap
+        @test merge(smaller, larger) == expected_superset
+        @test union([smaller, larger]) == [expected_superset]
         @test overlaps(smaller, larger)
         @test !contiguous(smaller, larger)
-        @test superset([smaller, larger]) == Interval(1, 5, true, true)
+        @test superset([smaller, larger]) == expected_superset
     end
 end

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -31,6 +31,8 @@
                 Interval{typeof(a)}(a, b, Inclusivity(true, false))
             @test Interval(b, a, Inclusivity(true, false)) ==
                 Interval{typeof(a)}(a, b, Inclusivity(false, true))
+            @test Interval(LeftEndpoint(a, true), RightEndpoint(b, true)) ==
+                Interval{typeof(a)}(a, b, Inclusivity(true, true))
         end
 
         # The three-argument Interval constructor can generate a StackOverflow if we aren't

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -21,18 +21,20 @@
         )
 
         for (a, b, _) in test_values
+            T = promote_type(typeof(a), typeof(b))
+
             @test a..b == Interval(a, b)
-            @test Interval(a, b) == Interval{typeof(a)}(a, b, Inclusivity(true, true))
+            @test Interval(a, b) == Interval{T}(a, b, Inclusivity(true, true))
             @test Interval(a, b, true, false) ==
-                Interval{typeof(a)}(a, b, Inclusivity(true, false))
-            @test Interval{typeof(a)}(a, b, true, false) ==
-                Interval{typeof(a)}(a, b, Inclusivity(true, false))
+                Interval{T}(a, b, Inclusivity(true, false))
+            @test Interval{T}(a, b, true, false) ==
+                Interval{T}(a, b, Inclusivity(true, false))
             @test Interval(a, b, Inclusivity(true, false)) ==
-                Interval{typeof(a)}(a, b, Inclusivity(true, false))
+                Interval{T}(a, b, Inclusivity(true, false))
             @test Interval(b, a, Inclusivity(true, false)) ==
-                Interval{typeof(a)}(a, b, Inclusivity(false, true))
+                Interval{T}(a, b, Inclusivity(false, true))
             @test Interval(LeftEndpoint(a, true), RightEndpoint(b, true)) ==
-                Interval{typeof(a)}(a, b, Inclusivity(true, true))
+                Interval{T}(a, b, Inclusivity(true, true))
         end
 
         # The three-argument Interval constructor can generate a StackOverflow if we aren't

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -1,5 +1,7 @@
-Base.isinf(x::Char) = false
-Base.isinf(x::TimeType) = false
+# Declare a new `isinf` function to avoid type piracy
+isinf(x) = Base.isinf(x)
+isinf(::Char) = false
+isinf(::TimeType) = false
 
 @testset "Interval" begin
     test_values = [

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -1,10 +1,20 @@
+Base.isinf(x::Char) = false
+Base.isinf(x::TimeType) = false
+
 @testset "Interval" begin
     test_values = [
         (-10, 1000, 1),
         (0.0, 1, 0.01),  # Use different types to test promotion
         ('a', 'z', 1),
         (Date(2013, 2, 13), Date(2013, 3, 13), Day(1)),
-        (DateTime(2016, 8, 11, 0, 30), DateTime(2016, 8, 11, 1), Millisecond(1))
+        (DateTime(2016, 8, 11, 0, 30), DateTime(2016, 8, 11, 1), Millisecond(1)),
+
+        # Infinite endpoints
+        (-Inf, 10, 1),
+        (10, Inf, 1),
+        (-Inf, Inf, 1),
+        (-Inf, 1.0, 0.01),
+        (0.0, Inf, 0.01),
     ]
 
     @testset "constructor" begin
@@ -140,46 +150,56 @@
             for i in 0:3
                 interval = Interval(a, b, Inclusivity(i))
                 cp = copy(interval)
-                lesser_val = Interval(a - unit, b + unit, Inclusivity(i))
+                lesser_val = Interval(a - unit, b - unit, Inclusivity(i))
                 greater_val = Interval(a + unit, b + unit, Inclusivity(i))
                 diff_inc = Interval(a, b, Inclusivity(mod(i + 1, 4)))
 
                 @test interval == cp
-                @test interval != lesser_val
-                @test interval != diff_inc
-
                 @test isequal(interval, cp)
-                @test !isequal(interval, lesser_val)
-                @test !isequal(interval, diff_inc)
-
                 @test hash(interval) == hash(cp)
-                @test hash(interval) != hash(lesser_val)
+
+                @test interval != diff_inc
+                @test !isequal(interval, diff_inc)
                 @test hash(interval) != hash(diff_inc)
+
+                if !isinf(a) || !isinf(b)
+                    @test interval != lesser_val
+                    @test !isequal(interval, lesser_val)
+                    @test hash(interval) != hash(lesser_val)
+                else
+                    @test interval == lesser_val
+                    @test isequal(interval, lesser_val)
+                    @test hash(interval) == hash(lesser_val)
+                end
 
                 @test !isless(interval, cp)
                 @test !(interval < cp)
                 @test !(interval ≪ cp)
                 @test !(interval > cp)
                 @test !(interval ≫ cp)
-                @test isless(interval, greater_val)
-                @test interval < greater_val
+
+                @test isless(interval, greater_val) || isinf(a)
+                @test interval < greater_val || isinf(a)
                 @test !(interval ≪ greater_val)     # Still overlap, so not disjoint
                 @test !(interval > greater_val)
                 @test !(interval ≫ greater_val)
+
                 @test !isless(greater_val, interval)
                 @test !(greater_val < interval)
                 @test !(greater_val ≪ interval)     # Still overlap, so not disjoint
-                @test greater_val > interval
+                @test greater_val > interval || isinf(a)
                 @test !(greater_val ≫ interval)     # Still overlap, so not disjoint
-                @test isless(lesser_val, interval)
-                @test lesser_val < interval
+
+                @test isless(lesser_val, interval) || isinf(a)
+                @test lesser_val < interval || isinf(a)
                 @test !(lesser_val ≪ interval)
                 @test !(lesser_val > interval)
                 @test !(lesser_val ≫ interval)
+
                 @test !isless(interval, lesser_val)
                 @test !(interval < lesser_val)
                 @test !(interval ≪ lesser_val)
-                @test interval > lesser_val
+                @test interval > lesser_val || isinf(a)
                 @test !(interval ≫ lesser_val)      # Still overlap, so not disjoint
             end
         end
@@ -302,9 +322,10 @@
         i1 = 1 .. 10
         i2 = Interval(1, 10, false, false)
         i3 = 2 .. 11
+        i4 = -Inf .. Inf
 
-        @test sort([i1, i2, i3]) == [i1, i2, i3]
-        @test sort([i1, i2, i3]; rev=true) == [i3, i2, i1]
+        @test sort([i1, i2, i3, i4]) == [i4, i1, i2, i3]
+        @test sort([i1, i2, i3, i4]; rev=true) == [i3, i2, i1, i4]
     end
 
     @testset "arithmetic" begin
@@ -371,36 +392,36 @@
     @testset "in" begin
         for (a, b, unit) in test_values
             interval = Interval(a, b)
-            @test in(a, interval)
-            @test in(a + unit, interval)
-            @test !in(a - unit, interval)
-            @test in(b, interval)
-            @test in(b - unit, interval)
-            @test !in(b + unit, interval)
+            @test  in(a, interval)
+            @test  in(a + unit, interval)
+            @test !in(a - unit, interval) || isinf(a)
+            @test  in(b, interval)
+            @test  in(b - unit, interval)
+            @test !in(b + unit, interval) || isinf(b)
 
             interval = Interval(a, b, Inclusivity(true, false))
-            @test in(a, interval)
-            @test in(a + unit, interval)
-            @test !in(a - unit, interval)
+            @test  in(a, interval)
+            @test  in(a + unit, interval)
+            @test !in(a - unit, interval) || isinf(a)
             @test !in(b, interval)
-            @test in(b - unit, interval)
+            @test  in(b - unit, interval) || isinf(b)
             @test !in(b + unit, interval)
 
             interval = Interval(a, b, Inclusivity(false, true))
             @test !in(a, interval)
-            @test in(a + unit, interval)
+            @test  in(a + unit, interval) || isinf(a)
             @test !in(a - unit, interval)
-            @test in(b, interval)
-            @test in(b - unit, interval)
-            @test !in(b + unit, interval)
+            @test  in(b, interval)
+            @test  in(b - unit, interval)
+            @test !in(b + unit, interval) || isinf(b)
 
             interval = Interval(a, b, Inclusivity(false, false))
             @test !in(a, interval)
-            @test in(a + unit, interval)
-            @test !in(a - unit, interval)
+            @test  in(a + unit, interval) || isinf(a)
+            @test !in(a - unit, interval) || isinf(a)
             @test !in(b, interval)
-            @test in(b - unit, interval)
-            @test !in(b + unit, interval)
+            @test  in(b - unit, interval) || isinf(b)
+            @test !in(b + unit, interval) || isinf(b)
 
             @test_throws ArgumentError (in(Interval(a, b), Interval(a, b)))
         end
@@ -554,11 +575,11 @@
             Interval(-100, -1, Inclusivity(false, false)),
             Interval(-10, -1, Inclusivity(false, false)),
             Interval(10, 15, Inclusivity(false, false)),
-            Interval(13, 20, Inclusivity(false, false))
+            Interval(13, 20, Inclusivity(false, false)),
         ]
         expected = [
             Interval(-100, -1, Inclusivity(false, false)),
-            Interval(10, 20, Inclusivity(false, false))
+            Interval(10, 20, Inclusivity(false, false)),
         ]
         @test union(intervals) == expected
 
@@ -567,16 +588,15 @@
             Interval(-100, -1, Inclusivity(false, false)),
             Interval(10, 15, Inclusivity(false, false)),
             Interval(-10, -1, Inclusivity(false, false)),
-            Interval(13, 20, Inclusivity(false, false))
+            Interval(13, 20, Inclusivity(false, false)),
         ]
         @test union(intervals) == expected
         @test intervals == [
             Interval(-100, -1, Inclusivity(false, false)),
             Interval(10, 15, Inclusivity(false, false)),
             Interval(-10, -1, Inclusivity(false, false)),
-            Interval(13, 20, Inclusivity(false, false))
+            Interval(13, 20, Inclusivity(false, false)),
         ]
-
         @test union!(intervals) == expected
         @test intervals == expected
 


### PR DESCRIPTION
Adapted from https://github.com/invenia/Intervals.jl/pull/95. Takes the, hopefully, non-controversial parts of that PR and uses the `Float64` infinity to validate the changes.

@fchorney doing this allowed me to go very carefully through your tests. I've removed a few of them that are redundant with those which are in comparison.jl and some were re-worked to avoid code duplication.