### PR TITLE
Deprecate invalid convert and unnecessary constructors

### DIFF
--- a/src/Intervals.jl
+++ b/src/Intervals.jl
@@ -20,6 +20,7 @@ include("interval.jl")
 include("anchoredinterval.jl")
 include("description.jl")
 include("plotting.jl")
+include("deprecated.jl")
 
 export AbstractInterval,
        Interval,

--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -169,8 +169,6 @@ function Base.convert(::Type{AnchoredInterval{Beginning}}, interval::Interval{T}
     AnchoredInterval{span(interval), T}(first(interval), inclusivity(interval))
 end
 
-Base.convert(::Type{T}, interval::AnchoredInterval{P, T}) where {P, T} = anchor(interval)
-
 # Date/DateTime attempt to convert to Int64 instead of falling back to convert(T, ...)
 Dates.Date(interval::AnchoredInterval{P, Date}) where P = convert(Date, interval)
 Dates.DateTime(interval::AnchoredInterval{P, DateTime}) where P = convert(DateTime, interval)

--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -169,10 +169,6 @@ function Base.convert(::Type{AnchoredInterval{Beginning}}, interval::Interval{T}
     AnchoredInterval{span(interval), T}(first(interval), inclusivity(interval))
 end
 
-# Date/DateTime attempt to convert to Int64 instead of falling back to convert(T, ...)
-Dates.Date(interval::AnchoredInterval{P, Date}) where P = convert(Date, interval)
-Dates.DateTime(interval::AnchoredInterval{P, DateTime}) where P = convert(DateTime, interval)
-
 ##### DISPLAY #####
 
 function Base.show(io::IO, interval::T) where T <: AnchoredInterval

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,10 @@
+using Base: depwarn
+
+# BEGIN Intervals 1.X.Y deprecations
+
+function Base.convert(::Type{T}, interval::AnchoredInterval{P, T}) where {P, T}
+    depwarn("`convert($T, interval::AnchoredInterval{P,$T})` is deprecated, use `anchor(interval)` instead.", :convert)
+    anchor(interval)
+end
+
+# END Intervals 1.X.Y deprecations

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -7,4 +7,11 @@ function Base.convert(::Type{T}, interval::AnchoredInterval{P, T}) where {P, T}
     anchor(interval)
 end
 
+for T in (:Date, :DateTime)
+    @eval function Dates.$T(interval::AnchoredInterval{P, $T}) where P
+        Base.depwarn("`$($T)(interval::AnchoredInterval{P,$($T)})` is deprecated, use `anchor(interval)` instead.", $(QuoteNode(T)))
+        return anchor(interval)
+    end
+end
+
 # END Intervals 1.X.Y deprecations

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -61,8 +61,18 @@ using Intervals: canonicalize
     @testset "conversion" begin
         he = HourEnding(dt)
         hb = HourBeginning(dt)
-        @test convert(DateTime, he) == dt
-        @test convert(DateTime, hb) == dt
+
+        if isempty(methods(convert, Tuple{Type{DateTime}, AnchoredInterval{Hour,DateTime}}))
+            @warn "Deprecation has been removed, cleanup tests appropriately"
+
+            # Disallow lossy conversions
+            @test_throws MethodError convert(DateTime, he)
+            @test_throws MethodError convert(DateTime, hb)
+        else
+            @test convert(DateTime, he) == dt
+            @test convert(DateTime, hb) == dt
+        end
+
         @test convert(Interval, he) == Interval(dt - Hour(1), dt, Inclusivity(false, true))
         @test convert(Interval, hb) == Interval(dt, dt + Hour(1), Inclusivity(true, false))
         @test convert(Interval, he) == Interval(dt - Hour(1), dt, Inclusivity(false, true))


### PR DESCRIPTION
Deprecated `convert` method as conversion [should be lossless](https://docs.julialang.org/en/v1/manual/conversion-and-promotion/#Conversion-vs.-Construction-1). 

The additional constructor methods were removed as they are unnecessary and are not scale-able. For example we don't have a `ZonedDateTime(::AnchoredInterval)` constructor or constructors for subtypes of `Real`.