### PR TITLE
Fix AnchoredInterval scalar convert instead of deprecating

### DIFF
--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -135,6 +135,16 @@ span(interval::AnchoredInterval{P}) where P = abs(P)
 
 ##### CONVERSION #####
 
+# Allows an interval to be converted to a scalar when the set contained by the interval only
+# contains a single element.
+function Base.convert(::Type{T}, interval::AnchoredInterval{P,T}) where {P,T}
+    if isclosed(interval) && (iszero(P) || first(interval) == last(interval))
+        return first(interval)
+    else
+        throw(DomainError(interval, "The interval is not closed with coinciding endpoints"))
+    end
+end
+
 function Base.convert(::Type{Interval}, interval::AnchoredInterval{P,T,L,R}) where {P,T,L,R}
     return Interval{T,L,R}(first(interval), last(interval))
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -6,11 +6,6 @@ import Dates: Date, DateTime
 export Inclusivity, inclusivity
 include("inclusivity.jl")
 
-function Base.convert(::Type{T}, interval::AnchoredInterval{P,T}) where {P,T}
-    depwarn("`convert($T, interval::AnchoredInterval{P,$T})` is deprecated, use `anchor(interval)` instead.", :convert)
-    anchor(interval)
-end
-
 @deprecate Date(interval::Interval{Date}) convert(Date, interval)
 @deprecate DateTime(interval::Interval{DateTime}) convert(DateTime, interval)
 @deprecate Date(interval::AnchoredInterval{P, Date} where P) convert(Date, interval)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,4 +1,5 @@
-using Base: depwarn
+using Base: @deprecate, depwarn
+import Dates: Date, DateTime
 
 # BEGIN Intervals 1.X.Y deprecations
 
@@ -10,12 +11,10 @@ function Base.convert(::Type{T}, interval::AnchoredInterval{P,T}) where {P,T}
     anchor(interval)
 end
 
-for T in (:Date, :DateTime)
-    @eval function Dates.$T(interval::AnchoredInterval{P, $T}) where P
-        depwarn("`$($T)(interval::AnchoredInterval{P,$($T)})` is deprecated, use `anchor(interval)` instead.", $(QuoteNode(T)))
-        return anchor(interval)
-    end
-end
+@deprecate Date(interval::Interval{Date}) convert(Date, interval)
+@deprecate DateTime(interval::Interval{DateTime}) convert(DateTime, interval)
+@deprecate Date(interval::AnchoredInterval{P, Date} where P) convert(Date, interval)
+@deprecate DateTime(interval::AnchoredInterval{P, DateTime} where P) convert(DateTime, interval)
 
 
 function Endpoint{T,D}(ep::T, included::Bool) where {T,D}

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -132,9 +132,14 @@ span(interval::Interval) = interval.last - interval.first
 
 ##### CONVERSION #####
 
-function Base.convert(::Type{T}, i::Interval{T}) where T
-    first(i) == last(i) && isclosed(i) && return first(i)
-    throw(DomainError(i, "The interval is not closed with coinciding endpoints"))
+# Allows an interval to be converted to a scalar when the set contained by the interval only
+# contains a single element.
+function Base.convert(::Type{T}, interval::Interval{T}) where T
+    if first(interval) == last(interval) && isclosed(interval)
+        return first(interval)
+    else
+        throw(DomainError(interval, "The interval is not closed with coinciding endpoints"))
+    end
 end
 
 ##### DISPLAY #####

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -137,10 +137,6 @@ function Base.convert(::Type{T}, i::Interval{T}) where T
     throw(DomainError(i, "The interval is not closed with coinciding endpoints"))
 end
 
-# Date/DateTime attempt to convert to Int64 instead of falling back to convert(T, ...)
-Dates.Date(interval::Interval{Date}) = convert(Date, interval)
-Dates.DateTime(interval::Interval{DateTime}) = convert(DateTime, interval)
-
 ##### DISPLAY #####
 
 function Base.show(io::IO, interval::T) where T <: Interval

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -57,20 +57,13 @@ using Intervals: canonicalize
     end
 
     @testset "conversion" begin
+        interval = AnchoredInterval{Hour(0)}(dt)
+        @test convert(DateTime, interval) == dt
+
         he = HourEnding(dt)
         hb = HourBeginning(dt)
-
-        if isempty(methods(convert, Tuple{Type{DateTime}, AnchoredInterval{Hour,DateTime}}))
-            @warn "Deprecation has been removed, cleanup tests appropriately"
-
-            # Disallow lossy conversions
-            @test_throws MethodError convert(DateTime, he)
-            @test_throws MethodError convert(DateTime, hb)
-        else
-            @test convert(DateTime, he) == dt
-            @test convert(DateTime, hb) == dt
-        end
-
+        @test_throws DomainError convert(DateTime, he)
+        @test_throws DomainError convert(DateTime, hb)
         @test convert(Interval, he) == Interval{Open, Closed}(dt - Hour(1), dt)
         @test convert(Interval, hb) == Interval{Closed, Open}(dt, dt + Hour(1))
         @test convert(Interval, he) == Interval{Open, Closed}(dt - Hour(1), dt)


### PR DESCRIPTION
A continuation of https://github.com/invenia/Intervals.jl/pull/101. In that PR I deprecated `convert(::Type{T}, ::AnchoredInterval{P,T})` as the conversion was lossy. Recently I noticed `convert(::Type{T}, ::Interval{T})` which converts intervals with only a single element into a scalar. It appears that the `AnchoredInterval` version of this function was just implemented incorrectly.

Testing of deprecations:
```julia
julia> using Intervals, Dates

julia> Date(Interval(today(), today()))
┌ Warning: `Date(interval::Interval{Date})` is deprecated, use `convert(Date, interval)` instead.
│   caller = ip:0x0
└ @ Core :-1
2020-06-23

julia> DateTime(Interval(now(), now()))
┌ Warning: `DateTime(interval::Interval{DateTime})` is deprecated, use `convert(DateTime, interval)` instead.
│   caller = ip:0x0
└ @ Core :-1
2020-06-23T14:38:18.26

julia> Date(AnchoredInterval{Hour(0)}(today()))
┌ Warning: `Date(interval::(AnchoredInterval{P, Date} where P))` is deprecated, use `convert(Date, interval)` instead.
│   caller = ip:0x0
└ @ Core :-1
2020-06-23

julia> DateTime(AnchoredInterval{Hour(0)}(now()))
┌ Warning: `DateTime(interval::(AnchoredInterval{P, DateTime} where P))` is deprecated, use `convert(DateTime, interval)` instead.
│   caller = ip:0x0
└ @ Core :-1
2020-06-23T14:38:39.605
```

I'll note we could probably remove these scalar convert methods as they have limited use but it's probably best to correct the function first.