### PR TITLE
Add deprecation for old scalar convert

### DIFF
--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -174,7 +174,17 @@ function Base.convert(::Type{T}, interval::AnchoredInterval{P,T}) where {P,T}
     if isclosed(interval) && (iszero(P) || first(interval) == last(interval))
         return first(interval)
     else
-        throw(DomainError(interval, "The interval is not closed with coinciding endpoints"))
+        # Remove deprecation in version 2.0.0
+        depwarn(
+            "`convert(T, interval::AnchoredInterval{P,T})` is deprecated for " *
+            "intervals which are not closed with coinciding endpoints. " *
+            "Use `anchor(interval)` instead.",
+            :convert,
+        )
+        return anchor(interval)
+
+        # TODO: For when deprecation is removed
+        # throw(DomainError(interval, "The interval is not closed with coinciding endpoints"))
     end
 end
 

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -107,8 +107,14 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
 
         he = HourEnding(dt)
         hb = HourBeginning(dt)
-        @test_throws DomainError convert(DateTime, he)
-        @test_throws DomainError convert(DateTime, hb)
+
+        # Note: When the deprecation is dropped remove the deprecated tests and uncomment
+        # the DomainError tests
+        @test (@test_deprecated convert(DateTime, he)) == anchor(he)
+        @test (@test_deprecated convert(DateTime, hb)) == anchor(hb)
+        # @test_throws DomainError convert(DateTime, he)
+        # @test_throws DomainError convert(DateTime, hb)
+
         @test convert(Interval, he) == Interval{Open, Closed}(dt - Hour(1), dt)
         @test convert(Interval, hb) == Interval{Closed, Open}(dt, dt + Hour(1))
         @test convert(Interval, he) == Interval{Open, Closed}(dt - Hour(1), dt)


### PR DESCRIPTION
I overlooked in https://github.com/invenia/Intervals.jl/pull/111 that I needed to have a deprecation when conversion was invalid.

Testing of deprecations
```julia
julia> using Intervals, Dates

julia> convert(DateTime, AnchoredInterval{Hour(0)}(DateTime(2000)))
2000-01-01T00:00:00

julia> convert(DateTime, HourEnding(DateTime(2000)))
┌ Warning: `convert(T, interval::AnchoredInterval{P,T})` is deprecated for intervals which are not closed with coinciding endpoints. Use `anchor(interval)` instead.
│   caller = top-level scope at REPL[3]:1
└ @ Core REPL[3]:1
2000-01-01T00:00:00
```