### PR TITLE
Add deprecation for full-type with inclusivity

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -31,6 +31,16 @@ function RightEndpoint(ep, included::Bool)
 end
 
 # intervals.jl
+function Interval{T,L,R}(f::T, l::T, inc::Inclusivity) where {T,L,R}
+    left_inc = bound_type(first(inc))
+    right_inc = bound_type(last(inc))
+    if L !== left_inc || R !== right_inc
+        throw(ArgumentError("Specified inclusivity ($(repr(left_inc)), $(repr(right_inc))) doesn't match bound types ($(repr(L)), $(repr(R)))"))
+    end
+    depwarn("`Interval{T,$(repr(L)),$(repr(R))}(f, l, $(repr(inc)))` is deprecated, use `Interval{T,$(repr(L)),$(repr(R))}(f, l)` instead.", :Interval)
+    return Interval{T,L,R}(f, l)
+end
+
 function Interval{T}(f, l, inc::Inclusivity) where T
     L = bound_type(first(inc))
     R = bound_type(last(inc))
@@ -65,6 +75,16 @@ function inclusivity(interval::AbstractInterval{T,L,R}) where {T,L,R}
 end
 
 # anchoredintervals.jl
+function AnchoredInterval{P,T,L,R}(anchor::T, inc::Inclusivity) where {P,T,L,R}
+    left_inc = bound_type(first(inc))
+    right_inc = bound_type(last(inc))
+    if L !== left_inc || R !== right_inc
+        throw(ArgumentError("Specified inclusivity ($(repr(left_inc)), $(repr(right_inc))) doesn't match bound types ($(repr(L)), $(repr(R)))"))
+    end
+    depwarn("`AnchoredInterval{P,T,$(repr(L)),$(repr(R))}(anchor, $(repr(inc)))` is deprecated, use `AnchoredInterval{P,T,$(repr(L)),$(repr(R))}(anchor)` instead.", :AnchoredInterval)
+    return AnchoredInterval{P,T,L,R}(anchor)
+end
+
 function AnchoredInterval{P,T}(anchor, inc::Inclusivity) where {P,T}
     L = bound_type(first(inc))
     R = bound_type(last(inc))

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -32,6 +32,10 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
         # Non-period AnchoredIntervals
         @test AnchoredInterval{-10}(10) isa AnchoredInterval
         @test AnchoredInterval{25}('a') isa AnchoredInterval
+
+        # Deprecated
+        @test_deprecated AnchoredInterval{Hour(-1),DateTime,Open,Closed}(dt, Inclusivity(false, true))
+        @test_throws ArgumentError AnchoredInterval{Hour(-1),DateTime,Open,Closed}(dt, Inclusivity(true, true))
     end
 
     @testset "zero-span" begin

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -58,6 +58,10 @@ isinf(::TimeType) = false
         @test_throws MethodError Interval{Int, Unbounded, Closed}(1, 2)
         @test_throws MethodError Interval{Int, Closed, Unbounded}(1, 2)
         @test_throws MethodError Interval{Int, Unbounded, Unbounded}(1, 2)
+
+        # Deprecated
+        @test_deprecated Interval{DateTime,Open,Closed}(DateTime(0), DateTime(0), Inclusivity(false, true))
+        @test_throws ArgumentError Interval{DateTime,Open,Closed}(DateTime(0), DateTime(0), Inclusivity(true, true))
     end
 
     @testset "non-ordered" begin


### PR DESCRIPTION
Fixes:
```julia
MethodError: no method matching AnchoredInterval{-1 hour,LaxZonedDateTimes.LaxZonedDateTime,Open,Closed}(::LaxZonedDateTimes.LaxZonedDateTime, ::Inclusivity)
Closest candidates are:
    AnchoredInterval{-1 hour,LaxZonedDateTimes.LaxZonedDateTime,Open,Closed}(::T) where {P, T, L<:Intervals.Bounded, R<:Intervals.Bounded} at /Users/admin/builds/f75a2375/0/invenia/BidPricing.jl.tmp/depot/packages/Intervals/jka4V/src/anchoredinterval.jl:72
    AnchoredInterval{-1 hour,LaxZonedDateTimes.LaxZonedDateTime,Open,Closed}(::Any) where {P, T, L, R} at /Users/admin/builds/f75a2375/0/invenia/BidPricing.jl.tmp/depot/packages/Intervals/jka4V/src/anchoredinterval.jl:95
```

Gets called when writing generic functions. Examples of deprecation in action:
```julia
julia> using Intervals, Dates

AnchoredInter
julia> AnchoredInterval{Hour(-1), DateTime, Open, Closed}(now(), Inclusivity(false, true))
┌ Warning: `Inclusivity(::Bool, ::Bool)` is deprecated and has no direct replacement. See `Interval` or `AnchoredInterval` constructors for alternatives.
│   caller = top-level scope at REPL[2]:1
└ @ Core REPL[2]:1
┌ Warning: `AnchoredInterval{P,T,Open,Closed}(anchor, Inclusivity(false, true))` is deprecated, use `AnchoredInterval{P,T,Open,Closed}(anchor)` instead.
│   caller = top-level scope at REPL[2]:1
└ @ Core REPL[2]:1
AnchoredInterval{-1 hour,DateTime,Open,Closed}(2020-06-24T15:51:32.255)

julia> Interval{Int, Open, Closed}(1, 2, Inclusivity(false, true))
┌ Warning: `Inclusivity(::Bool, ::Bool)` is deprecated and has no direct replacement. See `Interval` or `AnchoredInterval` constructors for alternatives.
│   caller = top-level scope at REPL[3]:1
└ @ Core REPL[3]:1
┌ Warning: `Interval{T,Open,Closed}(f, l, Inclusivity(false, true))` is deprecated, use `Interval{T,Open,Closed}(f, l)` instead.
│   caller = top-level scope at REPL[3]:1
└ @ Core REPL[3]:1
Interval{Int64,Open,Closed}(1, 2)

julia> Interval{Int, Open, Closed}(1, 2, Inclusivity(true, true))
┌ Warning: `Inclusivity(::Bool, ::Bool)` is deprecated and has no direct replacement. See `Interval` or `AnchoredInterval` constructors for alternatives.
│   caller = top-level scope at REPL[4]:1
└ @ Core REPL[4]:1
ERROR: ArgumentError: Specified inclusivity (Closed, Closed) doesn't match bound types (Open, Closed)
Stacktrace:
 [1] Interval{Int64,Open,Closed}(::Int64, ::Int64, ::Inclusivity) at /Users/omus/.julia/dev/Intervals/src/deprecated.jl:38
 [2] top-level scope at REPL[4]:1
```