### PR TITLE
Appveyor only tests plotting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@
 language: julia
 julia:
   - 1.0  # Latest LTS release
-  - 1  # Latest stable release
+  - 1    # Latest stable release
   - nightly
 os:
   - linux
-# - windows  # Can't use Travis to test windows because https://github.com/JuliaIO/FFMPEG.jl/issues/14
+  - windows
 arch:
   - x64
   - x86
@@ -25,6 +25,10 @@ jobs:
     - os: windows
       arch: x64
   include:
+    # Windows plotting tests fail on Travis CI due to: https://github.com/JuliaIO/FFMPEG.jl/issues/14
+    # Additionally, the build of FFMPEG.jl will fail but testing will still proceed
+    - os: windows
+      env: TESTS="-plotting"
     - stage: Documentation
       julia: 1.0
       script: julia --project=docs -e '

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,12 @@
 environment:
+  TESTS: plotting  # Limit Appveyor testing to just plotting as Travis is faster
   matrix:
-  - julia_version: 1.0  # latest LTS
-  - julia_version: 1  # latest stable
-  - julia_version: nightly
+    - julia_version: 1.0  # Latest LTS
+    - julia_version: 1    # Latest stable
+    - julia_version: nightly
 
 platform:
-  - x64 # 64-bit
+  - x64  # 64-bit
 
 matrix:
   allow_failures:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,12 +18,15 @@ const ALL_TESTS = (
 )
 
 const TESTS = let
-    tests = Symbol.(split(get(ENV, "TESTS", ""), r"\s+", keepempty=false))
-    if isempty(tests)
-        ALL_TESTS
-    else
-        tests
-    end
+    # e.g. `TESTS="interval comparisons"` or `TEST="-plotting"`
+    tests = split(get(ENV, "TESTS", ""), r"\s+", keepempty=false)
+
+    isexclude(x) = startswith(x, '-')
+    includes = Symbol.(filter(!isexclude, tests))
+    excludes = Symbol.(replace.(filter(isexclude, tests), Ref(r"^-" => "")))
+
+    isempty(includes) && (includes = ALL_TESTS)
+    setdiff(includes, excludes)
 end
 
 @testset "Intervals" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,13 +7,31 @@ using TimeZones
 
 const BOUND_PERMUTATIONS = product((Closed, Open), (Closed, Open))
 
-@testset "Intervals" begin
-    include("inclusivity.jl")
-    include("endpoint.jl")
-    include("interval.jl")
-    include("anchoredinterval.jl")
-    include("comparisons.jl")
-    include("plotting.jl")
+const ALL_TESTS = (
+    :inclusivity,
+    :endpoint,
+    :interval,
+    :anchoredinterval,
+    :comparisons,
+    :plotting,
+    :doctest,
+)
 
-    doctest(Intervals)
+const TESTS = let
+    tests = Symbol.(split(get(ENV, "TESTS", ""), r"\s+", keepempty=false))
+    if isempty(tests)
+        ALL_TESTS
+    else
+        tests
+    end
+end
+
+@testset "Intervals" begin
+    :inclusivity in TESTS && include("inclusivity.jl")
+    :endpoint in TESTS && include("endpoint.jl")
+    :interval in TESTS && include("interval.jl")
+    :anchoredinterval in TESTS && include("anchoredinterval.jl")
+    :comparisons in TESTS && include("comparisons.jl")
+    :plotting in TESTS && include("plotting.jl")
+    :doctest in TESTS && doctest(Intervals)
 end


### PR DESCRIPTION
I've updated the CI testing so that Appveyor only does plotting testing on Windows and Travis CI does the remainder of the Windows tests. Ideally this should decrease overall CI time. Note there is currently a bug with FFMPEG.jl and Trvais CI which means we cannot test plotting on Windows in Travis CI.