### PR TITLE
Add deprecation for full-type convert with inclusivity

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -41,6 +41,11 @@ function Interval{T,L,R}(f::T, l::T, inc::Inclusivity) where {T,L,R}
     return Interval{T,L,R}(f, l)
 end
 
+function Interval{T,L,R}(f, l, inc::Inclusivity) where {T,L,R}
+    # Using depwarn from next call
+    return Interval{T,L,R}(convert(T, f), convert(T, l), inc)
+end
+
 function Interval{T}(f, l, inc::Inclusivity) where T
     L = bound_type(first(inc))
     R = bound_type(last(inc))
@@ -83,6 +88,11 @@ function AnchoredInterval{P,T,L,R}(anchor::T, inc::Inclusivity) where {P,T,L,R}
     end
     depwarn("`AnchoredInterval{P,T,$(repr(L)),$(repr(R))}(anchor, $(repr(inc)))` is deprecated, use `AnchoredInterval{P,T,$(repr(L)),$(repr(R))}(anchor)` instead.", :AnchoredInterval)
     return AnchoredInterval{P,T,L,R}(anchor)
+end
+
+function AnchoredInterval{P,T,L,R}(anchor, inc::Inclusivity) where {P,T,L,R}
+    # Using depwarn from next call
+    return AnchoredInterval{P,T,L,R}(convert(T, anchor), inc)
 end
 
 function AnchoredInterval{P,T}(anchor, inc::Inclusivity) where {P,T}

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -36,6 +36,10 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
         # Deprecated
         @test_deprecated AnchoredInterval{Hour(-1),DateTime,Open,Closed}(dt, Inclusivity(false, true))
         @test_throws ArgumentError AnchoredInterval{Hour(-1),DateTime,Open,Closed}(dt, Inclusivity(true, true))
+
+        @test_deprecated AnchoredInterval{-1,Float64,Open,Closed}(0, Inclusivity(false, true))
+        @test_throws ArgumentError AnchoredInterval{-1,Float64,Open,Closed}(0, Inclusivity(true, true))
+        @test_throws MethodError AnchoredInterval{-1,Float64,Open,Closed}(nothing, Inclusivity(false, true))
     end
 
     @testset "zero-span" begin

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -62,6 +62,12 @@ isinf(::TimeType) = false
         # Deprecated
         @test_deprecated Interval{DateTime,Open,Closed}(DateTime(0), DateTime(0), Inclusivity(false, true))
         @test_throws ArgumentError Interval{DateTime,Open,Closed}(DateTime(0), DateTime(0), Inclusivity(true, true))
+
+        @test_deprecated Interval{Float64,Open,Closed}(0, 0, Inclusivity(false, true))
+        @test_throws ArgumentError Interval{Float64,Open,Closed}(0, 0, Inclusivity(true, true))
+        @test_throws MethodError Interval{Float64,Unbounded,Closed}(nothing, 0, Inclusivity(true, true))
+        @test_throws MethodError Interval{Float64,Open,Unbounded}(0, nothing, Inclusivity(false, true))
+        @test_throws ArgumentError Interval{Nothing,Unbounded,Unbounded}(nothing, nothing, Inclusivity(false, false))
     end
 
     @testset "non-ordered" begin


### PR DESCRIPTION
A constructor that doesn't seem to be used very often. Similar to: https://github.com/invenia/Intervals.jl/pull/114