### PR TITLE
Ensure non-bounded intervals contain orderable endpoints

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -77,10 +77,22 @@ struct Interval{T, L <: Bound, R <: Bound} <: AbstractInterval{T,L,R}
     end
 
     function Interval{T,L,R}(f::Nothing, l::T) where {T, L <: Unbounded, R <: Bounded}
+        # Note: Using `<` enforces that the type `T` defines `isless`
+        if !(l ≤ l)
+            throw(ArgumentError(
+                "Unable to determine an ordering between $l and other values of type $T"
+            ))
+        end
         return new{T,L,R}(l, l)
     end
 
     function Interval{T,L,R}(f::T, l::Nothing) where {T, L <: Bounded, R <: Unbounded}
+        # Note: Using `<` enforces that the type `T` defines `isless`
+        if !(f ≤ f)
+            throw(ArgumentError(
+                "Unable to determine an ordering between $f and other values of type $T"
+            ))
+        end
         return new{T,L,R}(f, f)
     end
 

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -33,6 +33,8 @@ isinf(::TimeType) = false
         )
 
         @test Interval(nothing, nothing) == Interval{Nothing, Unbounded, Unbounded}(nothing, nothing)
+        @test_throws MethodError Interval{Nothing, Open, Unbounded}(nothing, nothing)
+        @test_throws MethodError Interval{Nothing, Unbounded, Closed}(nothing, nothing)
 
         for (a, b, _) in test_values
             T = promote_type(typeof(a), typeof(b))
@@ -69,6 +71,9 @@ isinf(::TimeType) = false
         @test_throws ArgumentError Interval(NaN, Inf)
         @test_throws ArgumentError Interval(-Inf, NaN)
         # @test_throws ArgumentError Interval(Inf, -Inf)  # Would result in a NaN span
+
+        @test_throws ArgumentError Interval{Float64, Open, Unbounded}(NaN, nothing)
+        @test_throws ArgumentError Interval{Float64, Unbounded, Closed}(nothing, NaN)
     end
 
     @testset "hash" begin


### PR DESCRIPTION
With bounded intervals we ensure that the lower/upper endpoint values are ordered correctly. Attempting to pass in `NaN` fails as isn't comparable with any other `Float64` including itself. When one of the endpoints is unbounded this check didn't occur which allowed `NaN` to be used as an endpoint value. Additionally, `nothing` should only be allowed as an endpoint value when the endpoint bound type is set to `Unbounded`. Having the `≤` check also enforces this but does so with a `MethodError` as `isless(::Nothing)` is not defined.