### PR TITLE
Improve `Interval` constructor performance

### DIFF
--- a/src/interval.jl
+++ b/src/interval.jl
@@ -57,8 +57,8 @@ struct Interval{T, L <: Bound, R <: Bound} <: AbstractInterval{T,L,R}
 
     function Interval{T,L,R}(f::T, l::T) where {T, L <: Bounded, R <: Bounded}
         # Ensure that `first` preceeds `last`.
-        f, l, left_bound, right_bound = if f ≤ l
-            f, l, L, R
+        if f ≤ l
+            return new{T,L,R}(f, l)
         elseif l ≤ f
             # Note: Including the full stacktrace in this deprecation warning as most calls
             # to this inner constructor will be from other constructors.
@@ -68,12 +68,10 @@ struct Interval{T, L <: Bound, R <: Bound} <: AbstractInterval{T,L,R}
                 sprint(Base.show_backtrace, stacktrace()),
                 :Interval,
             )
-            l, f, R, L
+            return new{T,R,L}(l, f)
         else
             throw(ArgumentError("Unable to determine an ordering between: $f and $l"))
         end
-
-        return new{T, left_bound, right_bound}(f, l)
     end
 
     function Interval{T,L,R}(f::Nothing, l::T) where {T, L <: Unbounded, R <: Bounded}

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -60,12 +60,12 @@ struct Interval{T, L <: Bound, R <: Bound} <: AbstractInterval{T,L,R}
         if f ≤ l
             return new{T,L,R}(f, l)
         elseif l ≤ f
-            # Note: Including the full stacktrace in this deprecation warning as most calls
-            # to this inner constructor will be from other constructors.
+            # Note: Most calls to this inner constructor will be from other constructors
+            # which may make it hard to identify the source of this deprecation. Use
+            # `--depwarn=error` to see a full stack trace.
             Base.depwarn(
                 "Constructing an `Interval{T,X,Y}(x, y)` " *
-                "where `x > y` is deprecated, use `Interval{T,Y,X}(y, x)` instead." *
-                sprint(Base.show_backtrace, stacktrace()),
+                "where `x > y` is deprecated, use `Interval{T,Y,X}(y, x)` instead.",
                 :Interval,
             )
             return new{T,R,L}(l, f)


### PR DESCRIPTION
Intervals 1.2.0:
```julia
julia> using Intervals, TimeZones, BenchmarkTools

julia> zdt = ZonedDateTime(2000, 1, 1, tz"UTC")
2000-01-01T00:00:00+00:00

julia> @benchmark Interval{ZonedDateTime}($zdt, $zdt, $(Inclusivity(false, true)))
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     7.507 ns (0.00% GC)
  median time:      7.883 ns (0.00% GC)
  mean time:        10.706 ns (9.95% GC)
  maximum time:     1.757 μs (99.35% GC)
  --------------
  samples:          10000
  evals/sample:     999
```

Intervals 1.3.3:
```julia
julia> using Intervals, TimeZones, BenchmarkTools

julia> zdt = ZonedDateTime(2000, 1, 1, tz"UTC")
2000-01-01T00:00:00+00:00

julia> @benchmark Interval{ZonedDateTime,Open,Closed}($zdt, $zdt)
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     121.008 ns (0.00% GC)
  median time:      124.039 ns (0.00% GC)
  mean time:        152.110 ns (0.81% GC)
  maximum time:     2.975 μs (88.58% GC)
  --------------
  samples:          10000
  evals/sample:     905
```

Using this PR:
```julia
julia> using Intervals, TimeZones, BenchmarkTools

julia> zdt = ZonedDateTime(2000, 1, 1, tz"UTC")
2000-01-01T00:00:00+00:00

julia> @benchmark Interval{ZonedDateTime,Open,Closed}($zdt, $zdt)
BenchmarkTools.Trial:
  memory estimate:  32 bytes
  allocs estimate:  1
  --------------
  minimum time:     8.932 ns (0.00% GC)
  median time:      9.934 ns (0.00% GC)
  mean time:        13.088 ns (8.52% GC)
  maximum time:     2.315 μs (99.29% GC)
  --------------
  samples:          10000
  evals/sample:     999
```
Removing the stacktrace call does seem to slightly help but mainly I removed it as it's a kind of weird thing to do and is unnecessary since `--depwarn=error` exists.