### PR TITLE
Support deserialize on previous interval structs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ version = "1.3.4"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]

--- a/src/Intervals.jl
+++ b/src/Intervals.jl
@@ -3,6 +3,7 @@ module Intervals
 using Dates
 using Printf
 using RecipesBase
+using Serialization: Serialization, AbstractSerializer, deserialize
 using TimeZones
 
 using Dates: AbstractDateTime, value, coarserperiod
@@ -30,6 +31,7 @@ include("description.jl")
 include("plotting.jl")
 include("docstrings.jl")
 include("deprecated.jl")
+include("serialization.jl")
 
 export Bound,
        Closed,

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -1,0 +1,31 @@
+# These `deserialize` methods are used to be able to deserialize intervals using the
+# structure that was used before Intervals 1.3.
+
+struct _LegacyInterval{T}
+    first::T
+    last::T
+    inclusivity::Inclusivity
+end
+
+function Serialization.deserialize(s::AbstractSerializer, ::Type{Interval{T}}) where T
+    old = deserialize(s, _LegacyInterval{T})
+
+    L = bound_type(first(old.inclusivity))
+    R = bound_type(last(old.inclusivity))
+
+    return Interval{T,L,R}(old.first, old.last)
+end
+
+struct _LegacyAnchoredInterval{P,T}
+    anchor::T
+    inclusivity::Inclusivity
+end
+
+function Serialization.deserialize(s::AbstractSerializer, ::Type{AnchoredInterval{P,T}}) where {P,T}
+    old = deserialize(s, _LegacyAnchoredInterval{P,T})
+
+    L = bound_type(first(old.inclusivity))
+    R = bound_type(last(old.inclusivity))
+
+    return AnchoredInterval{P,T,L,R}(old.anchor)
+end

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -735,4 +735,19 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
         ai = AnchoredInterval{Day(1)}(zdt)
         @test timezone(ai) == tz"America/Winnipeg"
     end
+
+    @testset "legacy deserialization" begin
+        # Serialized string generated on Intervals@1.2 with:
+        # `julia --project -E 'using Serialization, Intervals; sprint(serialize, AnchoredInterval{-1,Int}(2, true, false))'`.
+        buffer = IOBuffer(
+            SERIALIZED_HEADER *
+            "\x004\x10\x01\x10AnchoredInterval\x1f\v՞\x84\xec\xf7-`\x87\xbb" *
+            "S\xe1Á\x88A\xd8\x01\tIntervalsD\x02\0\0\x001\xff\xff\xff\xff\0\b\xe14\x10" *
+            "\x01\vInclusivity\x1f\v՞\x84\xec\xf7-`\x87\xbbS\xe1Á\x88A\xd8,\x02\0DML"
+        )
+
+        interval = deserialize(buffer)
+        @test interval isa AnchoredInterval
+        @test interval == AnchoredInterval{-1,Int,Closed,Open}(2)
+    end
 end

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -631,4 +631,19 @@ isinf(::TimeType) = false
         ]
         @test union(intervals) == [Interval{Open, Closed}(-100, -1)]
     end
+
+    @testset "legacy deserialization" begin
+        # Serialized string generated on Intervals@1.2 with:
+        # `julia --project -E 'using Serialization, Intervals; sprint(serialize, Interval(1, 2, true, false))'`.
+        buffer = IOBuffer(
+            SERIALIZED_HEADER *
+            "\x004\x10\x01\bInterval\x1f\v՞\x84\xec\xf7-`\x87\xbbS\xe1Á\x88A\xd8\x01\t" *
+            "IntervalsD\x01\0\0\0\0\b\xe0\xe14\x10\x01\vInclusivity\x1f\v՞\x84\xec\xf7" *
+            "-`\x87\xbbS\xe1Á\x88A\xd8,\x02\0DML"
+        )
+
+        interval = deserialize(buffer)
+        @test interval isa Interval
+        @test interval == Interval{Closed,Open}(1, 2)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,10 +2,13 @@ using Base.Iterators: product
 using Dates
 using Documenter: doctest
 using Intervals
+using Serialization: deserialize
 using Test
 using TimeZones
 
 const BOUND_PERMUTATIONS = product((Closed, Open), (Closed, Open))
+
+include("test_utils.jl")
 
 @testset "Intervals" begin
     include("inclusivity.jl")

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,13 @@
+# Note: To support testing against the latest Julia nightly we'll assume the serialization
+# format is the same as the last version of Julia we've tested against.
+const SERIALIZED_HEADER = if VERSION >= v"1.5"
+    "7JL\n\x04\0\0"
+elseif VERSION >= v"1.4"
+    "7JL\t\x04\0\0"
+elseif VERSION >= v"1.2"
+    "7JL\b\x04\0\0"
+elseif VERSION >= v"1.0"
+    "7JL\a\x04\0\0"
+else
+    error("Julia versions earlier than 1.0 are unsupported")
+end


### PR DESCRIPTION
Added to allow JLSO files saved with the older intervals structure to load transparently. Note that Julia serialization isn't guaranteed to work across versions of Julia but this should work on the same version of Julia with different versions of Intervals.