### PR TITLE
Restrict doctests to use Julia 1.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: julia
 julia:
   - 1.0  # Latest LTS release
-  - 1  # Latest stable release
+  - 1    # Latest stable release
   - nightly
 os:
   - linux
@@ -26,7 +26,7 @@ jobs:
       arch: x64
   include:
     - stage: Documentation
-      julia: 1.0
+      julia: 1.5
       script: julia --project=docs -e '
           using Pkg;
           Pkg.develop(PackageSpec(path=pwd()));

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -13,9 +13,9 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "88bb0edb352b16608036faadcc071adda068582a"
+git-tree-sha1 = "c5714d9bcdba66389612dc4c47ed827c64112997"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.1"
+version = "0.8.2"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
@@ -39,10 +39,10 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[Intervals]]
-deps = ["Dates", "Printf", "RecipesBase", "TimeZones"]
+deps = ["Dates", "Printf", "RecipesBase", "Serialization", "TimeZones"]
 path = ".."
 uuid = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
-version = "1.2.0"
+version = "1.3.4"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -51,6 +51,7 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.0"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -58,9 +59,9 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[Libiconv_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "e5256a3b0ebc710dbd6da0c0b212164a3681037f"
+git-tree-sha1 = "c9d4035d7481bcdff2babf5a55525a818ef8ed8f"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.0+2"
+version = "1.16.0+5"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -80,12 +81,12 @@ version = "0.7.1"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "eb3e09940c0d7ae01b01d9291ebad7b081c844d3"
+git-tree-sha1 = "10134f2ee0b1978ae7752c41306e131a684e1f06"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.5"
+version = "1.0.7"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -133,12 +134,12 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[XML2_jll]]
 deps = ["Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "987c02a43fa10a491a5f0f7c46a6d3559ed6a8e2"
+git-tree-sha1 = "432d91f45e950f2f2bda5c0f4e2b938c14493af9"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.9+4"
+version = "2.9.10+1"
 
 [[Zlib_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "a2e0d558f6031002e380a90613b199e37a8565bf"
+git-tree-sha1 = "622d8b6dc0c7e8029f17127703de9819134d1b71"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+10"
+version = "1.2.11+14"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,8 @@ makedocs(;
     authors="Invenia Technical Computing Corporation",
     checkdocs=:exports,
     strict=true,
+    # Note: The output of the doctests currently requires a newer version of Julia
+    doctest=(VERSION >= v"1.5.0-DEV.163"),  # https://github.com/JuliaLang/julia/pull/34387
 )
 
 deploydocs(;

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,6 +4,10 @@
 DocTestSetup = quote
     using Intervals, Dates, TimeZones
 end
+DocTestFilters = [
+    r"AnchoredInterval\{(Day|Hour|Minute)\(-\d+\),|HourEnding\{",
+    r"AnchoredInterval\{(Day|Hour|Minute)\(\d+\),|HourBeginning\{",
+]
 ```
 
 This package defines:
@@ -74,13 +78,13 @@ julia> string(a)
 julia> using Dates
 
 julia> b = Interval{Closed,Open}(Date(2013), Date(2016))
-Interval{Date,Closed,Open}(2013-01-01, 2016-01-01)
+Interval{Date,Closed,Open}(Date("2013-01-01"), Date("2016-01-01"))
 
 julia> string(b)
 "[2013-01-01 .. 2016-01-01)"
 
 julia> c = HourEnding(DateTime(2016, 8, 11))
-AnchoredInterval{-1 hour,DateTime,Open,Closed}(2016-08-11T00:00:00)
+AnchoredInterval{Hour(-1),DateTime,Open,Closed}(DateTime("2016-08-11T00:00:00"))
 
 julia> string(c)
 "(2016-08-10 HE24]"
@@ -92,13 +96,13 @@ julia> string(c)
 julia> using TimeZones, Dates
 
 julia> unrounded = HourEnding(ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg"))
-AnchoredInterval{-1 hour,ZonedDateTime,Open,Closed}(ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg"))
+AnchoredInterval{Hour(-1),ZonedDateTime,Open,Closed}(ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg"))
 
 julia> he = HE(ZonedDateTime(2013, 2, 13, 0, 30, tz"America/Winnipeg"))
-AnchoredInterval{-1 hour,ZonedDateTime,Open,Closed}(ZonedDateTime(2013, 2, 13, 1, tz"America/Winnipeg"))
+AnchoredInterval{Hour(-1),ZonedDateTime,Open,Closed}(ZonedDateTime(2013, 2, 13, 1, tz"America/Winnipeg"))
 
 julia> he + Hour(1)
-AnchoredInterval{-1 hour,ZonedDateTime,Open,Closed}(ZonedDateTime(2013, 2, 13, 2, tz"America/Winnipeg"))
+AnchoredInterval{Hour(-1),ZonedDateTime,Open,Closed}(ZonedDateTime(2013, 2, 13, 2, tz"America/Winnipeg"))
 
 julia> foreach(println, he:he + Day(1))
 (2013-02-13 HE01-06:00]
@@ -143,7 +147,7 @@ julia> start_dt = DateTime(2017,1,1,0,0,0);
 julia> end_dt = DateTime(2017,1,1,10,30,0);
 
 julia> datetimes = start_dt:Hour(1):end_dt
-2017-01-01T00:00:00:1 hour:2017-01-01T10:00:00
+DateTime("2017-01-01T00:00:00"):Hour(1):DateTime("2017-01-01T10:00:00")
 
 julia> intervals = HE.(datetimes);
 
@@ -165,13 +169,13 @@ endpoints (taking bounds into account):
 
 ```jldoctest
 julia> a = Interval{Closed,Open}(DateTime(2013, 2, 13), DateTime(2013, 2, 13, 1))
-Interval{DateTime,Closed,Open}(2013-02-13T00:00:00, 2013-02-13T01:00:00)
+Interval{DateTime,Closed,Open}(DateTime("2013-02-13T00:00:00"), DateTime("2013-02-13T01:00:00"))
 
 julia> b = Interval{Open,Closed}(DateTime(2013, 2, 13), DateTime(2013, 2, 13, 1))
-Interval{DateTime,Open,Closed}(2013-02-13T00:00:00, 2013-02-13T01:00:00)
+Interval{DateTime,Open,Closed}(DateTime("2013-02-13T00:00:00"), DateTime("2013-02-13T01:00:00"))
 
 julia> c = HourEnding(DateTime(2013, 2, 13, 1))
-AnchoredInterval{-1 hour,DateTime,Open,Closed}(2013-02-13T01:00:00)
+AnchoredInterval{Hour(-1),DateTime,Open,Closed}(DateTime("2013-02-13T01:00:00"))
 
 julia> a == b
 false

--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -27,33 +27,33 @@ To this end, `HourEnding` is a type alias for `AnchoredInterval{Hour(-1)}`. Simi
 While the user may expect an `HourEnding` or `HourBeginning` value to be anchored to a
 specific hour, the constructor makes no guarantees that the anchor provided is rounded:
 
-```jldoctest; setup = :(using Intervals, Dates)
+```jldoctest; setup = :(using Intervals, Dates), filter = r"AnchoredInterval\\{(Day|Hour|Minute)\\(-?\\d+\\),|Hour(Ending|Beginning)\\{"
 julia> HourEnding(DateTime(2016, 8, 11, 2, 30))
-AnchoredInterval{-1 hour,DateTime,Open,Closed}(2016-08-11T02:30:00)
+AnchoredInterval{Hour(-1),DateTime,Open,Closed}(DateTime("2016-08-11T02:30:00"))
 ```
 
 The `HE` and `HB` pseudoconstructors round the input up or down to the nearest hour, as
 appropriate:
 
-```jldoctest; setup = :(using Intervals, Dates)
+```jldoctest; setup = :(using Intervals, Dates), filter = r"AnchoredInterval\\{(Day|Hour|Minute)\\(-?\\d+\\),|Hour(Ending|Beginning)\\{"
 julia> HE(DateTime(2016, 8, 11, 2, 30))
-AnchoredInterval{-1 hour,DateTime,Open,Closed}(2016-08-11T03:00:00)
+AnchoredInterval{Hour(-1),DateTime,Open,Closed}(DateTime("2016-08-11T03:00:00"))
 
 julia> HB(DateTime(2016, 8, 11, 2, 30))
-AnchoredInterval{1 hour,DateTime,Closed,Open}(2016-08-11T02:00:00)
+AnchoredInterval{Hour(1),DateTime,Closed,Open}(DateTime("2016-08-11T02:00:00"))
 ```
 
 ### Example
 
-```jldoctest; setup = :(using Intervals, Dates)
+```jldoctest; setup = :(using Intervals, Dates), filter = r"AnchoredInterval\\{(Day|Hour|Minute)\\(-?\\d+\\),|Hour(Ending|Beginning)\\{"
 julia> AnchoredInterval{Hour(-1)}(DateTime(2016, 8, 11, 12))
-AnchoredInterval{-1 hour,DateTime,Open,Closed}(2016-08-11T12:00:00)
+AnchoredInterval{Hour(-1),DateTime,Open,Closed}(DateTime("2016-08-11T12:00:00"))
 
 julia> AnchoredInterval{Day(1)}(DateTime(2016, 8, 11))
-AnchoredInterval{1 day,DateTime,Closed,Open}(2016-08-11T00:00:00)
+AnchoredInterval{Day(1),DateTime,Closed,Open}(DateTime("2016-08-11T00:00:00"))
 
 julia> AnchoredInterval{Minute(5),Closed,Closed}(DateTime(2016, 8, 11, 12, 30))
-AnchoredInterval{5 minutes,DateTime,Closed,Closed}(2016-08-11T12:30:00)
+AnchoredInterval{Minute(5),DateTime,Closed,Closed}(DateTime("2016-08-11T12:30:00"))
 ```
 
 See also: [`Interval`](@ref), [`HE`](@ref), [`HB`](@ref)

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -225,10 +225,17 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
         where_lr = "where R<:$Bounded where L<:$Bounded"
         where_tlr = "$where_lr where T"
 
-        @test sprint(show, AnchoredInterval{Hour(-1)}) ==
-            "AnchoredInterval{$(repr(Hour(-1))),T,L,R} $where_tlr"
-        @test sprint(show, AnchoredInterval{Hour(1)}) ==
-            "AnchoredInterval{$(repr(Hour(1))),T,L,R} $where_tlr"
+        if VERSION >= v"1.6.0-DEV.347"
+            @test sprint(show, AnchoredInterval{Hour(-1)}) ==
+                "HourEnding{T,L,R} $where_tlr"
+            @test sprint(show, AnchoredInterval{Hour(1)}) ==
+                "HourBeginning{T,L,R} $where_tlr"
+        else
+            @test sprint(show, AnchoredInterval{Hour(-1)}) ==
+                "AnchoredInterval{$(repr(Hour(-1))),T,L,R} $where_tlr"
+            @test sprint(show, AnchoredInterval{Hour(1)}) ==
+                "AnchoredInterval{$(repr(Hour(1))),T,L,R} $where_tlr"
+        end
 
         @test sprint(show, AnchoredInterval{Day(-1)}) ==
             "AnchoredInterval{$(repr(Day(-1))),T,L,R} $where_tlr"
@@ -245,7 +252,11 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                 HourEnding(dt),
                 "(2016-08-11 HE02]",
                 string(
-                    "AnchoredInterval{$(repr(Hour(-1))),DateTime,Open,Closed}",
+                    if VERSION >= v"1.6.0-DEV.347"
+                        "HourEnding{DateTime,Open,Closed}"
+                    else
+                        "AnchoredInterval{$(repr(Hour(-1))),DateTime,Open,Closed}"
+                    end,
                     "($(repr(DateTime(2016, 8, 11, 2))))",
                 ),
             ),
@@ -253,7 +264,11 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                 HourEnding{Closed, Open}(DateTime(2013, 2, 13)),
                 "[2013-02-12 HE24)",
                 string(
-                    "AnchoredInterval{$(repr(Hour(-1))),DateTime,Closed,Open}",
+                    if VERSION >= v"1.6.0-DEV.347"
+                        "HourEnding{DateTime,Closed,Open}"
+                    else
+                        "AnchoredInterval{$(repr(Hour(-1))),DateTime,Closed,Open}"
+                    end,
                     "($(repr(DateTime(2013, 2, 13))))",
                 ),
             ),
@@ -261,7 +276,11 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                 HourEnding(dt + Minute(15) + Second(30)),
                 "(2016-08-11 HE02:15:30]",
                 string(
-                    "AnchoredInterval{$(repr(Hour(-1))),DateTime,Open,Closed}",
+                    if VERSION >= v"1.6.0-DEV.347"
+                        "HourEnding{DateTime,Open,Closed}"
+                    else
+                        "AnchoredInterval{$(repr(Hour(-1))),DateTime,Open,Closed}"
+                    end,
                     "($(repr(DateTime(2016, 8, 11, 2, 15, 30))))",
                 ),
             ),
@@ -269,7 +288,11 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                 HourEnding(dt + Millisecond(2)),
                 "(2016-08-11 HE02:00:00.002]",
                 string(
-                    "AnchoredInterval{$(repr(Hour(-1))),DateTime,Open,Closed}",
+                    if VERSION >= v"1.6.0-DEV.347"
+                        "HourEnding{DateTime,Open,Closed}"
+                    else
+                        "AnchoredInterval{$(repr(Hour(-1))),DateTime,Open,Closed}"
+                    end,
                     "($(repr(DateTime(2016, 8, 11, 2, 0, 0, 2))))",
                 ),
             ),
@@ -277,7 +300,11 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                 HourEnding{Closed, Open}(DateTime(2013, 2, 13, 0, 1)),
                 "[2013-02-13 HE00:01:00)",
                 string(
-                    "AnchoredInterval{$(repr(Hour(-1))),DateTime,Closed,Open}",
+                    if VERSION >= v"1.6.0-DEV.347"
+                        "HourEnding{DateTime,Closed,Open}"
+                    else
+                        "AnchoredInterval{$(repr(Hour(-1))),DateTime,Closed,Open}"
+                    end,
                     "($(repr(DateTime(2013, 2, 13, 0, 1))))",
                 ),
             ),
@@ -285,7 +312,11 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                 HourBeginning(dt),
                 "[2016-08-11 HB02)",
                 string(
-                    "AnchoredInterval{$(repr(Hour(1))),DateTime,Closed,Open}",
+                    if VERSION >= v"1.6.0-DEV.347"
+                        "HourBeginning{DateTime,Closed,Open}"
+                    else
+                        "AnchoredInterval{$(repr(Hour(1))),DateTime,Closed,Open}"
+                    end,
                     "($(repr(DateTime(2016, 8, 11, 2))))",
                 ),
             ),
@@ -293,7 +324,11 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                 HourBeginning{Open, Closed}(DateTime(2013, 2, 13)),
                 "(2013-02-13 HB00]",
                 string(
-                    "AnchoredInterval{$(repr(Hour(1))),DateTime,Open,Closed}",
+                    if VERSION >= v"1.6.0-DEV.347"
+                        "HourBeginning{DateTime,Open,Closed}"
+                    else
+                        "AnchoredInterval{$(repr(Hour(1))),DateTime,Open,Closed}"
+                    end,
                     "($(repr(DateTime(2013, 2, 13))))",
                 ),
             ),
@@ -301,7 +336,11 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                 HourEnding(ZonedDateTime(dt, tz"America/Winnipeg")),
                 "(2016-08-11 HE02-05:00]",
                 string(
-                    "AnchoredInterval{$(repr(Hour(-1))),$ZonedDateTime,Open,Closed}",
+                    if VERSION >= v"1.6.0-DEV.347"
+                        "HourEnding{$ZonedDateTime,Open,Closed}"
+                    else
+                        "AnchoredInterval{$(repr(Hour(-1))),$ZonedDateTime,Open,Closed}"
+                    end,
                     "($(repr(ZonedDateTime(dt, tz"America/Winnipeg"))))",
                 ),
             ),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,5 +18,11 @@ include("test_utils.jl")
     include("comparisons.jl")
     include("plotting.jl")
 
-    doctest(Intervals)
+    # Note: The output of the doctests currently requires a newer version of Julia
+    # https://github.com/JuliaLang/julia/pull/34387
+    if VERSION >= v"1.5.0-DEV.163"
+        doctest(Intervals)
+    else
+        @warn "Skipping doctests"
+    end
 end


### PR DESCRIPTION
I noticed some printing tests were failing with Julia 1.6 so I fixed them and also needed to update the doctests. During process of updating the doctests I found that using filtering to make the doctests work on all version of Julia supported by this package would result in the date values just being ignored. To prevent that I decided to restrict the doctesting to just be on Julia 1.5 and 1.6 so that the doctests are actually still performing a reasonable amount of testing.