### PR TITLE
Support RecipesBase 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 Documenter = "0.23, 0.24"
-RecipesBase = "0.8, 1"
+RecipesBase = "0.7, 0.8, 1"
 TimeZones = "0.7, 0.8, 0.9, 0.10, 0.11, 1"
 julia = "1"
 


### PR DESCRIPTION
Tested locally on macOS that RecipesBase 0.7.0 passes tests. Note in order to use this version https://github.com/JuliaTime/TimeZones.jl/pull/280 is required.