### PR TITLE
Eliminate legacy serialization structs

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,33 +1,25 @@
 # These `deserialize` methods are used to be able to deserialize intervals using the
 # structure that was used before Intervals 1.3.
 
-struct _LegacyInterval{T}
-    first::T
-    last::T
-    inclusivity::Inclusivity
-end
-
 function Serialization.deserialize(s::AbstractSerializer, ::Type{Interval{T}}) where T
-    old = deserialize(s, _LegacyInterval{T})
+    left = deserialize(s)
+    right = deserialize(s)
+    inclusivity = deserialize(s)
 
-    L = bound_type(first(old.inclusivity))
-    R = bound_type(last(old.inclusivity))
+    L = bound_type(first(inclusivity))
+    R = bound_type(last(inclusivity))
 
-    return Interval{T,L,R}(old.first, old.last)
-end
-
-struct _LegacyAnchoredInterval{P,T}
-    anchor::T
-    inclusivity::Inclusivity
+    return Interval{T,L,R}(left, right)
 end
 
 function Serialization.deserialize(s::AbstractSerializer, ::Type{AnchoredInterval{P,T}}) where {P,T}
-    old = deserialize(s, _LegacyAnchoredInterval{P,T})
+    anchor = deserialize(s)
+    inclusivity = deserialize(s)
 
-    L = bound_type(first(old.inclusivity))
-    R = bound_type(last(old.inclusivity))
+    L = bound_type(first(inclusivity))
+    R = bound_type(last(inclusivity))
 
-    return AnchoredInterval{P,T,L,R}(old.anchor)
+    return AnchoredInterval{P,T,L,R}(anchor)
 end
 
 # Works around an issue where a `StepRangeLen` tries to convert the step to an


### PR DESCRIPTION
Just cleaning up this serialization compatibility code. I'm a little more familiar with custom serialization now and this seemed to be a better approach.