### PR TITLE
Refactor generic `isfinite` support

### DIFF
--- a/src/Intervals.jl
+++ b/src/Intervals.jl
@@ -24,6 +24,7 @@ Base.eltype(::AbstractInterval{T}) where {T} = T
 Base.broadcastable(x::AbstractInterval) = Ref(x)
 bounds_types(x::AbstractInterval{T,L,R}) where {T,L,R} = (L, R)
 
+include("isfinite.jl")
 include("endpoint.jl")
 include("interval.jl")
 include("anchoredinterval.jl")

--- a/src/anchoredinterval.jl
+++ b/src/anchoredinterval.jl
@@ -69,7 +69,7 @@ struct AnchoredInterval{P, T, L <: Bounded, R <: Bounded} <: AbstractInterval{T,
         #
         # We can skip computing the other endpoint if both the anchor and span are finite as
         # this ensures the computed endpoint is also finite.
-        if !_isfinite(anchor) || !_isfinite(P)
+        if !isfinite(anchor) || !isfinite(P)
             left, right = sign(P) < 0 ? (anchor + P, anchor) : (anchor, anchor + P)
 
             if !(left <= right)
@@ -87,9 +87,6 @@ struct AnchoredInterval{P, T, L <: Bounded, R <: Bounded} <: AbstractInterval{T,
         return new{P,T,L,R}(anchor)
     end
 end
-
-_isfinite(x) = iszero(x - x)
-_isfinite(x::Real) = Base.isfinite(x)
 
 function AnchoredInterval{P,T,L,R}(interval::AnchoredInterval{P,T,L,R}) where {P,T,L,R}
     AnchoredInterval{P,T,L,R}(interval.anchor)

--- a/src/isfinite.jl
+++ b/src/isfinite.jl
@@ -1,0 +1,4 @@
+# Declare a new `isfinite` function to avoid type piracy. This new function works with
+# `Char` and `Period` as well as other types.
+isfinite(x) = iszero(x - x)
+isfinite(x::Real) = Base.isfinite(x)

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -1,8 +1,3 @@
-# Declare a new `isinf` function to avoid type piracy
-isinf(x) = Base.isinf(x)
-isinf(::Char) = false
-isinf(::TimeType) = false
-
 @testset "Interval" begin
     test_values = [
         (-10, 1000, 1),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Base.Iterators: product
 using Dates
 using Documenter: doctest
 using Intervals
+using Intervals: isfinite
 using Serialization: deserialize
 using Test
 using TimeZones

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -11,3 +11,12 @@ elseif VERSION >= v"1.0"
 else
     error("Julia versions earlier than 1.0 are unsupported")
 end
+
+# Declare a new `isnan` and `isinf` functions to avoid type piracy. These new function work
+# with `Char` and `Period` types as well as other types.
+# Note: A generic `isfinite` is declared in Intervals.
+isnan(x) = (x != x)::Bool
+isnan(x::Real) = Base.isnan(x)
+
+isinf(x) = !isnan(x) && !isfinite(x)
+isinf(x::Real) = Base.isinf(x)


### PR DESCRIPTION
As `isfinite(::Char)` is something that [isn't desired to be supported in Base](https://github.com/JuliaLang/julia/pull/36380#issuecomment-690646495) I'll refactor the Intervals.jl code to make internal support for this more reasonable.