### PR TITLE
Add GHA badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/Intervals.jl/stable)
 [![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/Intervals.jl/latest)
 [![CI](https://github.com/Invenia/Intervals.jl/workflows/CI/badge.svg)](https://github.com/Invenia/Intervals.jl/actions?query=workflow%3ACI)
-[![JuliaNightly](https://github.com/Invenia/Intervals.jl/workflows/JuliaNightly/badge.svg)](https://github.com/Invenia/Intervals.jl/actions?query=workflow%3AJuliaNightly)
 [![CodeCov](https://codecov.io/gh/invenia/Intervals.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/Intervals.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/Intervals.jl/stable)
 [![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/Intervals.jl/latest)
 [![CI](https://github.com/Invenia/Intervals.jl/workflows/CI/badge.svg)](https://github.com/Invenia/Intervals.jl/actions?query=workflow%3ACI)
+[![JuliaNightly](https://github.com/Invenia/Intervals.jl/workflows/JuliaNightly/badge.svg)](https://github.com/Invenia/Intervals.jl/actions?query=workflow%3AJuliaNightly)
 [![CodeCov](https://codecov.io/gh/invenia/Intervals.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/Intervals.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/Intervals.jl/stable)
 [![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://invenia.github.io/Intervals.jl/latest)
-[![Build Status](https://travis-ci.com/invenia/Intervals.jl.svg?branch=master)](https://travis-ci.com/invenia/Intervals.jl)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/invenia/Intervals.jl?svg=true)](https://ci.appveyor.com/project/invenia/Intervals-jl)
+[![CI](https://github.com/Invenia/Intervals.jl/workflows/CI/badge.svg)](https://github.com/Invenia/Intervals.jl/actions?query=workflow%3ACI)
 [![CodeCov](https://codecov.io/gh/invenia/Intervals.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/Intervals.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 


### PR DESCRIPTION
Forgot to do this with the previous github actions PR.
Added the CI badge, and the JuliaNightly badge, but do we actually want the JuliaNightly badge to be on the README?