### PR TITLE
Add `prefix` methods for `Week` and `Quarter` Types.  

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Intervals"
 uuid = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "1.5.0"
+version = "1.5.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/description.jl
+++ b/src/description.jl
@@ -60,7 +60,6 @@ function prefix(p::Period)
 end
 
 prefix(::Type{Year}) = "Y"
-prefix(::Type{Quarter}) = "Q"
 prefix(::Type{Month}) = "Mo"
 prefix(::Type{Week}) = "W"
 prefix(::Type{Day}) = "D"
@@ -69,5 +68,10 @@ prefix(::Type{Minute}) = "M"
 prefix(::Type{Second}) = "S"
 prefix(::Type{Millisecond}) = "ms"
 
-# informative error if no prefix is defined for the givne type.
+# `Quarter` defined after Julia1.6.
+if VERSION >= v"1.6"
+    prefix(::Type{Quarter}) = "Q"
+end
+
+# informative error if no prefix is defined for the given type.
 prefix(T::Type{<:Period}) = error("A prefix for period $T has not yet been defined")

--- a/src/description.jl
+++ b/src/description.jl
@@ -43,15 +43,20 @@ function description(dt::AbstractDateTime, p::Period, suffix::String)
 end
 
 function time_string(dt::AbstractDateTime, p::Period)
-    t = (hour(dt), minute(dt), second(dt), millisecond(dt))
+    t = (hour(dt), minute(dt), second(dt), millisecond(dt), microsecond(Time(dt)), nanosecond(Time(dt)))
+    println(t)
     if p isa Hour && all(t[2:end] .== 0)
         return @sprintf("%02d", t[1])
     elseif p isa Minute && all(t[3:end] .== 0)
         return @sprintf("%02d:%02d", t[1:2]...)
-    elseif !isa(p, Millisecond) && t[4] == 0
+    elseif p isa Millisecond && all(t[4:end] .== 0)
         return @sprintf("%02d:%02d:%02d", t[1:3]...)
+    elseif p isa Microsecond && all(t[5:end] .== 0)
+        return @sprintf("%02d:%02d:%02d.%03d", t[1:4]...)
+    elseif !isa(p, Nanosecond) && t[6] == 0
+        return @sprintf("%02d:%02d:%02d.%03d.%03d", t[1:5]...)
     else
-        return @sprintf("%02d:%02d:%02d.%03d", t...)
+        return @sprintf("%02d:%02d:%02d.%03d.%03d.%03d", t...)
     end
 end
 
@@ -61,8 +66,11 @@ end
 
 prefix(::Type{Year}) = "Y"
 prefix(::Type{Month}) = "Mo"
+prefix(::Type{Week}) = "We"
 prefix(::Type{Day}) = "D"
 prefix(::Type{Hour}) = "H"
 prefix(::Type{Minute}) = "M"
 prefix(::Type{Second}) = "S"
 prefix(::Type{Millisecond}) = "ms"
+prefix(::Type{Microsecond}) = "μs"
+prefix(::Type{Nanosecond}) = "ns"

--- a/src/description.jl
+++ b/src/description.jl
@@ -43,20 +43,15 @@ function description(dt::AbstractDateTime, p::Period, suffix::String)
 end
 
 function time_string(dt::AbstractDateTime, p::Period)
-    t = (hour(dt), minute(dt), second(dt), millisecond(dt), microsecond(Time(dt)), nanosecond(Time(dt)))
-    println(t)
+    t = (hour(dt), minute(dt), second(dt), millisecond(dt))
     if p isa Hour && all(t[2:end] .== 0)
         return @sprintf("%02d", t[1])
     elseif p isa Minute && all(t[3:end] .== 0)
         return @sprintf("%02d:%02d", t[1:2]...)
-    elseif p isa Millisecond && all(t[4:end] .== 0)
+    elseif !isa(p, Millisecond) && t[4] == 0
         return @sprintf("%02d:%02d:%02d", t[1:3]...)
-    elseif p isa Microsecond && all(t[5:end] .== 0)
-        return @sprintf("%02d:%02d:%02d.%03d", t[1:4]...)
-    elseif !isa(p, Nanosecond) && t[6] == 0
-        return @sprintf("%02d:%02d:%02d.%03d.%03d", t[1:5]...)
     else
-        return @sprintf("%02d:%02d:%02d.%03d.%03d.%03d", t...)
+        return @sprintf("%02d:%02d:%02d.%03d", t...)
     end
 end
 
@@ -65,12 +60,14 @@ function prefix(p::Period)
 end
 
 prefix(::Type{Year}) = "Y"
+prefix(::Type{Quarter}) = "Q"
 prefix(::Type{Month}) = "Mo"
-prefix(::Type{Week}) = "We"
+prefix(::Type{Week}) = "W"
 prefix(::Type{Day}) = "D"
 prefix(::Type{Hour}) = "H"
 prefix(::Type{Minute}) = "M"
 prefix(::Type{Second}) = "S"
 prefix(::Type{Millisecond}) = "ms"
-prefix(::Type{Microsecond}) = "μs"
-prefix(::Type{Nanosecond}) = "ns"
+
+# informative error if no prefix is defined for the givne type.
+prefix(T::Type{<:Period}) = error("A prefix for period $T has not yet been defined")

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -585,6 +585,13 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
             "AnchoredInterval{25,Char,Closed,Open}('a')"
         end
         @test sprint(show, interval) == shown
+
+        # Error if no prefix defined for the given period type
+        interval = AnchoredInterval{Microsecond(-1)}(Date(dt))
+        @test_throws ErrorException sprint(print, interval)
+
+        interval = AnchoredInterval{Nanosecond(-1)}(Date(dt))
+        @test_throws ErrorException sprint(print, interval)
     end
 
     @testset "equality" begin

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -525,31 +525,7 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                     end,
                     "($(repr(DateTime(2016, 8, 11, 2))))",
                 ),
-           ),
-           (
-                AnchoredInterval{Microsecond(-10)}(dt),
-                "(2016-08-11 10μsE02:00:00.000.000]",
-                string(
-                    if VERSION >= v"1.6.0"
-                        "AnchoredInterval{$(repr(Microsecond(-10))), DateTime, Open, Closed}"
-                    else
-                        "AnchoredInterval{$(repr(Microsecond(-10))),DateTime,Open,Closed}"
-                    end,
-                    "($(repr(DateTime(2016, 8, 11, 2))))",
-                    ),
-                ), 
-            (
-                AnchoredInterval{Nanosecond(-10)}(dt),
-                "(2016-08-11 10nsE02:00:00:00.000.000.000]",
-                string(
-                    if VERSION >= v"1.6.0"
-                        "AnchoredInterval{$(repr(Nanosecond(-10))), DateTime, Open, Closed}"
-                    else
-                        "AnchoredInterval{$(repr(Nanosecond(-10))),DateTime,Open,Closed}"
-                    end,
-                    "($(repr(DateTime(2016, 8, 11, 2))))",
-                ),
-            ),   
+           ), 
         ]
 
         for (interval, printed, shown) in tests

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -426,6 +426,18 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                 ),
             ),
             (
+                AnchoredInterval{Week(-1)}(dt),
+                "(WE 2016-08-11 02:00:00]",
+                string(
+                    if VERSION >= v"1.6.0"
+                        "AnchoredInterval{$(repr(Week(-1))), DateTime, Open, Closed}"
+                    else
+                        "AnchoredInterval{$(repr(Week(-1))),DateTime,Open,Closed}"
+                    end,
+                    "($(repr(DateTime(2016, 8, 11, 2, 0, 0))))",
+                ),
+            ),
+            (
                 AnchoredInterval{Week(-1)}(ceil(dt, Week)),
                 "(WE 2016-08-15]",
                 string(
@@ -525,8 +537,20 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                     end,
                     "($(repr(DateTime(2016, 8, 11, 2))))",
                 ),
-           ), 
+           ),
         ]
+
+        # add test for `Quarter`, only defined after Julia1.6
+        if VERSION >= v"1.6"
+            entry = (AnchoredInterval{Quarter(-1)}(ceil(Date(dt), Quarter)),
+                "(QE 2016-10-01]",
+                string(
+                    "AnchoredInterval{$(repr(Quarter(-1))), Date, Open, Closed}",
+                    "($(repr(Date(2016, 10, 01))))",
+                ),
+            )
+            push!(tests, entry)
+        end
 
         for (interval, printed, shown) in tests
             @test sprint(print, interval) == printed

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -426,6 +426,18 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                 ),
             ),
             (
+                AnchoredInterval{Week(-1)}(ceil(dt, Week)),
+                "(WE 2016-08-15]",
+                string(
+                    if VERSION >= v"1.6.0"
+                        "AnchoredInterval{$(repr(Week(-1))), DateTime, Open, Closed}"
+                    else
+                        "AnchoredInterval{$(repr(Week(-1))),DateTime,Open,Closed}"
+                    end,
+                    "($(repr(DateTime(2016, 8, 15))))",
+                ),
+            ),
+            (
                 AnchoredInterval{Day(-1)}(DateTime(dt)),
                 "(DE 2016-08-11 02:00:00]",
                 string(
@@ -514,6 +526,30 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
                     "($(repr(DateTime(2016, 8, 11, 2))))",
                 ),
            ),
+           (
+                AnchoredInterval{Microsecond(-10)}(dt),
+                "(2016-08-11 10μsE02:00:00.000.000]",
+                string(
+                    if VERSION >= v"1.6.0"
+                        "AnchoredInterval{$(repr(Microsecond(-10))), DateTime, Open, Closed}"
+                    else
+                        "AnchoredInterval{$(repr(Microsecond(-10))),DateTime,Open,Closed}"
+                    end,
+                    "($(repr(DateTime(2016, 8, 11, 2))))",
+                    ),
+                ), 
+            (
+                AnchoredInterval{Nanosecond(-10)}(dt),
+                "(2016-08-11 10nsE02:00:00:00.000.000.000]",
+                string(
+                    if VERSION >= v"1.6.0"
+                        "AnchoredInterval{$(repr(Nanosecond(-10))), DateTime, Open, Closed}"
+                    else
+                        "AnchoredInterval{$(repr(Nanosecond(-10))),DateTime,Open,Closed}"
+                    end,
+                    "($(repr(DateTime(2016, 8, 11, 2))))",
+                ),
+            ),   
         ]
 
         for (interval, printed, shown) in tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,12 +13,12 @@ const BOUND_PERMUTATIONS = product((Closed, Open), (Closed, Open))
 include("test_utils.jl")
 
 @testset "Intervals" begin
-    include("inclusivity.jl")
-    include("endpoint.jl")
-    include("interval.jl")
+    #include("inclusivity.jl")
+    #include("endpoint.jl")
+    #include("interval.jl")
     include("anchoredinterval.jl")
-    include("comparisons.jl")
-    include("plotting.jl")
+    #include("comparisons.jl")
+    #include("plotting.jl")
 
     # Note: The output of the doctests currently requires a newer version of Julia
     # https://github.com/JuliaLang/julia/pull/34387

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,12 +13,12 @@ const BOUND_PERMUTATIONS = product((Closed, Open), (Closed, Open))
 include("test_utils.jl")
 
 @testset "Intervals" begin
-    #include("inclusivity.jl")
-    #include("endpoint.jl")
-    #include("interval.jl")
+    include("inclusivity.jl")
+    include("endpoint.jl")
+    include("interval.jl")
     include("anchoredinterval.jl")
-    #include("comparisons.jl")
-    #include("plotting.jl")
+    include("comparisons.jl")
+    include("plotting.jl")
 
     # Note: The output of the doctests currently requires a newer version of Julia
     # https://github.com/JuliaLang/julia/pull/34387


### PR DESCRIPTION
partially tackles #163 

I haven't included prefixes for `Microsecond` or `Nanosecond` because as far as I can tell, `DateTime`s are only defined up to millisecond precision (see https://github.com/JuliaLang/julia/issues/31525). I wasn't sure if we wanted to display `DateTime` Intervals with greater precision than what is available for `DateTime`s.


I also haven't added tests for `Quarter` because it's not clear to me how to get around the fact that this type was only introduced in Julia v1.6. Any advice there would be appreciated. 