### PR TITLE
Fix plotting in Plots > v.1.11

### DIFF
--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -5,24 +5,25 @@ interval_marker(x::Type{Open}) = :none
 
 # TODO: Add support for plotting unbounded intervals
 @recipe function f(xs::AbstractVector{<:AbstractInterval{T,L,R}}, ys) where {T, L <: Bounded, R <: Bounded}
-    new_xs = T[]
-    new_ys = []
+    new_xs = Vector{T}[]
+    new_ys = Vector{Any}[]
     markers = Symbol[]
     for (x, y) in zip(xs, ys)
-        # To cause line to not be connected, need to add a breaker point with
-        # NaN in one of the coordinates. We put that in `new_ys` as that is probably a
-        # float. where-as new_xs is potentially a DateTime etc that would not accept NaN
-        append!(new_xs, [first(x), last(x), last(x)])
-        append!(new_ys, [y, y, NaN])
-        append!(markers, interval_markers(x))
-        push!(markers, :none)
+        # To cause line to not be connected, need to divide individually separated segments into separate vectors
+        # This is as of v1.11 in Plots.
+        # See https://github.com/JuliaPlots/Plots.jl/blob/master/src/utils.jl#L104
+        append!(new_xs, [[first(x), last(x)]])
+        append!(new_ys, [[y, y]])
     end
-
+    append!(markers, interval_markers(first(xs)))
+    
     # Work around GR bug that shows :none as a marker
     # TODO: remove once https://github.com/jheinen/GR.jl/issues/295  is fixed
     markeralpha := [x == :none ? 0 : 1 for x in markers]
 
     markershape := markers
     seriestype  := :path  # always a path, even in a scatter plot
+
     new_xs, new_ys
+    
 end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -23,7 +23,5 @@ interval_marker(x::Type{Open}) = :none
 
     markershape := markers
     seriestype  := :path  # always a path, even in a scatter plot
-
     new_xs, new_ys
-    
 end


### PR DESCRIPTION
Fixes #https://github.com/invenia/Intervals.jl/issues/159

Plots changes the way it handles line segments. Instead of `NaN` separated, it uses a vector of points (see issue). 

Should we keep support for Plots < v1.11