### PR TITLE
Default to short printing for REPL

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,23 +32,23 @@ This package defines:
 
 ```jldoctest
 julia> a = 1..10
-Interval{Int64, Closed, Closed}(1, 10)
+[1 .. 10]
 
 julia> b = 5..15
-Interval{Int64, Closed, Closed}(5, 15)
+[5 .. 15]
 
 julia> intersect(a, b)
-Interval{Int64, Closed, Closed}(5, 10)
+[5 .. 10]
 ```
 
 ### Bounds
 
 ```jldoctest
 julia> a = Interval{Closed, Closed}(1, 10)
-Interval{Int64, Closed, Closed}(1, 10)
+[1 .. 10]
 
 julia> b = Interval{Open, Open}(5, 15)
-Interval{Int64, Open, Open}(5, 15)
+(5 .. 15)
 
 julia> 5 in a
 true
@@ -57,10 +57,10 @@ julia> 5 in b
 false
 
 julia> intersect(a, b)
-Interval{Int64, Open, Closed}(5, 10)
+(5 .. 10]
 
 julia> c = Interval(15, 20)
-Interval{Int64, Closed, Closed}(15, 20)
+[15 .. 20]
 
 julia> isempty(intersect(b, c))
 true
@@ -70,7 +70,10 @@ true
 
 ```jldoctest
 julia> a = Interval('a', 'z')
-Interval{Char, Closed, Closed}('a', 'z')
+[a .. z]
+
+julia> repr(a)
+"Interval{Char, Closed, Closed}('a', 'z')"
 
 julia> string(a)
 "[a .. z]"
@@ -78,7 +81,10 @@ julia> string(a)
 julia> using Dates
 
 julia> b = Interval{Closed, Open}(Date(2013), Date(2016))
-Interval{Date, Closed, Open}(Date("2013-01-01"), Date("2016-01-01"))
+[2013-01-01 .. 2016-01-01)
+
+julia> repr(b)
+"Interval{Date, Closed, Open}(Date(\"2013-01-01\"), Date(\"2016-01-01\"))"
 
 julia> string(b)
 "[2013-01-01 .. 2016-01-01)"
@@ -169,10 +175,10 @@ endpoints (taking bounds into account):
 
 ```jldoctest
 julia> a = Interval{Closed, Open}(DateTime(2013, 2, 13), DateTime(2013, 2, 13, 1))
-Interval{DateTime, Closed, Open}(DateTime("2013-02-13T00:00:00"), DateTime("2013-02-13T01:00:00"))
+[2013-02-13T00:00:00 .. 2013-02-13T01:00:00)
 
 julia> b = Interval{Open, Closed}(DateTime(2013, 2, 13), DateTime(2013, 2, 13, 1))
-Interval{DateTime, Open, Closed}(DateTime("2013-02-13T00:00:00"), DateTime("2013-02-13T01:00:00"))
+(2013-02-13T00:00:00 .. 2013-02-13T01:00:00]
 
 julia> c = HourEnding(DateTime(2013, 2, 13, 1))
 HourEnding{DateTime, Open, Closed}(DateTime("2013-02-13T01:00:00"))
@@ -219,13 +225,13 @@ endpoint should be used for rounding. Valid options are `:left`, `:right`, or
 
 ```jldoctest
 julia> floor(Interval(0.0, 1.0), on=:left)
-Interval{Float64, Closed, Closed}(0.0, 1.0)
+[0.0 .. 1.0]
 
 julia> floor(Interval(0.5, 1.0), on=:left)
-Interval{Float64, Closed, Closed}(0.0, 0.5)
+[0.0 .. 0.5]
 
 julia> floor(Interval(0.5, 1.5), on=:right)
-Interval{Float64, Closed, Closed}(0.0, 1.0)
+[0.0 .. 1.0]
 ```
 
 Anchored intervals default to rounding using the anchor point.

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -272,6 +272,7 @@ function Base.show(io::IO, interval::Interval{T,L,R}) where {T,L,R}
         print(io, ")")
     end
 end
+Base.show(io::IO, ::MIME"text/plain", interval::Interval) = print(io, interval)
 
 function Base.print(io::IO, interval::AbstractInterval{T,L,R}) where {T,L,R}
     # Print to io in order to keep properties like :limit and :compact


### PR DESCRIPTION
The printing choices in this package are somewhat non-standard
with respect to how Base defines printing, though that is
probably Base's fault for not documenting how these are
supposed to be used properly. In particular, this package
uses the :compact switch to decide between a parseable,
verbose printing and a compact, human-readable printing.

However, these are orthogonal concepts, and the :compact
switch isn't really supposed to switch the parsability.
Parsability vs non-parsibility is the distinction between
`show(io::IO, x)` (parseable) and `show(io::IO, MIME"text/plain"(), x)`
(non-parseable, pretty for humans). The latter is also
what is used for display in REPL contexts whereas the former
is used for repr.

I would like to suggest that the REPL printing should also
default to the human-readable version. For example, I
wanted to use intervals of units in a package, but the
default output looks very scary for first time Julia users:

```
julia> using Intervals, Unitful

julia> 1dB..2dB
Interval{Gain{Unitful.LogInfo{:Decibel, 10, 10}, :?, Int64}, Closed, Closed}(1 dB, 2 dB)
```

Admittedly that is mostly because of the scary Unitful type,
but still. We have better printing, why not use it. After this PR,
the compact printing is used at the REPL:

```
julia> 1dB..2dB
[1 dB .. 2 dB]
```