### PR TITLE
Support printing weeks and quarters

### DIFF
--- a/src/description.jl
+++ b/src/description.jl
@@ -60,7 +60,9 @@ function prefix(p::Period)
 end
 
 prefix(::Type{Year}) = "Y"
+prefix(::Type{Quarter}) = "Q"
 prefix(::Type{Month}) = "Mo"
+prefix(::Type{Week}) = "W"
 prefix(::Type{Day}) = "D"
 prefix(::Type{Hour}) = "H"
 prefix(::Type{Minute}) = "M"


### PR DESCRIPTION
Before
```julia
julia> string(AnchoredInterval{Week(1)}(floor(today(), Week)))
ERROR: MethodError: no method matching prefix(::Type{Week})
Closest candidates are:
  prefix(::Period) at ~/.julia/dev/Intervals/src/description.jl:58
  prefix(::Type{Year}) at ~/.julia/dev/Intervals/src/description.jl:62
  prefix(::Type{Month}) at ~/.julia/dev/Intervals/src/description.jl:63
  ...
Stacktrace:
 [1] prefix(p::Week)
   @ Intervals ~/.julia/dev/Intervals/src/description.jl:59
 [2] description(dt::Date, p::Week, suffix::String)
   @ Intervals ~/.julia/dev/Intervals/src/description.jl:22
 [3] description(interval::AnchoredInterval{Week(1), Date, Closed, Open}, s::String)
   @ Intervals ~/.julia/dev/Intervals/src/description.jl:4
 [4] description(i::AnchoredInterval{Week(1), Date, Closed, Open})
   @ Intervals ~/.julia/dev/Intervals/src/description.jl:1
 [5] print(io::IOBuffer, interval::AnchoredInterval{Week(1), Date, Closed, Open})
   @ Intervals ~/.julia/dev/Intervals/src/anchoredinterval.jl:256
 [6] print_to_string(xs::AnchoredInterval{Week(1), Date, Closed, Open})
   @ Base ./strings/io.jl:144
 [7] string(xs::AnchoredInterval{Week(1), Date, Closed, Open})
   @ Base ./strings/io.jl:185
 [8] top-level scope
   @ REPL[26]:1
```
After
```julia
julia> string(AnchoredInterval{Week(1)}(floor(today(), Week)))
"[WB 2022-06-06)"
```