### PR TITLE
Tests, docs and some small fixes to IntervalSets

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -268,6 +268,7 @@ In the plot, inclusive boundaries are marked with a vertical bar, whereas exclus
 ```@docs
 Interval
 AnchoredInterval
+IntervalSet
 HourEnding
 HourBeginning
 HE
@@ -291,4 +292,5 @@ Base.parse(::Type{Interval{T}}, ::AbstractString) where T
 union
 union!
 superset
+Intervals.find_intersections
 ```

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -1,6 +1,12 @@
 
 ###### Set-related Helpers #####
 
+"""
+    IntervalSet(x::AbstractVector{<:AbstractInterval})
+
+Interpret an array of intervals as a set of points: the union of all points in the
+intervals.
+"""
 struct IntervalSet{T<:AbstractInterval}
     items::Vector{<:AbstractInterval}
 end

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -9,6 +9,8 @@ intervals. Set operations over them will return an IntervalSet containing the
 fewest number of intervals that can be used to represent the resulting point set. 
 Unbounded intervals are not supported.
 
+see also: https://en.wikipedia.org/wiki/Interval_arithmetic#Interval_operators
+
 ## Examples
 
 ```jldoctest

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -146,7 +146,7 @@ function unbunch((i, interval)::Tuple, tracking; lt=isless)
     return eltype[(i, LeftEndpoint(interval)), (i, RightEndpoint(interval))]
 end
 
-function unbunch(a::Union{AbstractVector{<:AbstractInterval}, AbstractIntervals, 
+function unbunch(a::Union{AbstractVector{<:AbstractInterval}, AbstractIntervals}, 
                  b::Union{AbstractVector{<:AbstractInterval}, AbstractIntervals}; kwargs...)
     tracking = endpoint_tracking(a, b)
     a_ = unbunch(a, tracking; kwargs...)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -401,10 +401,10 @@ Base.intersect(x::IntervalSet, y::IntervalSet) = mergesets((inx, iny) -> inx && 
 Base.union(x::IntervalSet, y::IntervalSet) = mergesets((inx, iny) -> inx || iny, x, y)
 Base.setdiff(x::IntervalSet, y::IntervalSet) = mergesets((inx, iny) -> inx && !iny, x, y)
 Base.symdiff(x::IntervalSet, y::IntervalSet) = mergesets((inx, iny) -> inx ⊻ iny, x, y)
-Base.issubset(x::AbstractIntervalSets, y::AbstractIntervalSets) = isempty(setdiff(x, y))
-Base.isdisjoint(x::AbstractIntervalSets, y::AbstractIntervalSets) = isempty(intersect(x, y))
+Base.issubset(x::AbstractIntervals, y::AbstractIntervals) = isempty(setdiff(x, y))
+Base.isdisjoint(x::AbstractIntervals, y::AbstractIntervals) = isempty(intersect(x, y))
 
-function Base.issetequal(x::AbstractIntervalSets, y::AbstractIntervalSets)
+function Base.issetequal(x::AbstractIntervals, y::AbstractIntervals)
     x, y, tracking = unbunch(union(IntervalSet(x)), union(IntervalSet(y)))
     return x == y || all(isempty, bunch(x, tracking)) && all(isempty, bunch(y, tracking))
 end

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -63,17 +63,32 @@ Base.eltype(::IntervalSet{T}) where T = T
 Base.:(==)(a::IntervalSet, b::IntervalSet) = issetequal(a, b)
 Base.isequal(a::IntervalSet, b::IntervalSet) = isequal(a.items, b.items)
 Base.convert(::Type{T}, intervals::IntervalSet) where T <: AbstractArray = convert(T, intervals.items)
-function Base.show(io::IO, ::MIME"text/plain", x::IntervalSet) 
+function Base.show(io::Base.AbstractPipe, ::MIME"text/plain", x::IntervalSet) 
     intervals = union(x)
     iocompact = IOContext(io, :compact => true)
     print(io, "$(length(intervals))-interval ")
     show(io, MIME"text/plain"(), typeof(x))
     println(io, ":")
-    for interval in intervals.items[1:(end-1)]
-        show(iocompact, MIME"text/plain"(), interval)
-        println(io, "")
+    nrows = displaysize(io)[1]
+    half = fld(nrows, 2) - 2
+    if nrows ≥ length(intervals.items) && half > 1
+        for interval in intervals.items[1:(end-1)]
+            show(iocompact, MIME"text/plain"(), interval)
+            println(io, "")
+        end
+        isempty(intervals) || show(iocompact, MIME"text/plain"(), intervals.items[end])
+    else
+        for interval in intervals.items[1:half]
+            show(iocompact, MIME"text/plain"(), interval)
+            println(io, "")
+        end
+        println(io, "⋮")
+        for interval in intervals.items[(end-half+1):end-1]
+            show(iocompact, MIME"text/plain"(), interval)
+            println(io, "")
+        end
+        show(iocompact, MIME"text/plain"(), intervals.items[end])
     end
-    isempty(intervals) || show(iocompact, MIME"text/plain"(), intervals.items[end])
 end
 
 # currently (to avoid breaking changes) new methods for `Base`

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -14,35 +14,35 @@ see also: https://en.wikipedia.org/wiki/Interval_arithmetic#Interval_operators
 
 ```jldoctest
 julia> using Intervals
-julia> Array(union(IntervalSet(1..5), IntervalSet(3..8)))
+julia> convert(Array, union(IntervalSet(1..5), IntervalSet(3..8)))
 1-element Vector{Interval{Int64, Closed, Closed}}:
  Interval{Int64, Closed, Closed}(1, 8)
 
-julia> Array(intersect(IntervalSet(1..5), IntervalSet(3..8)))
+julia> convert(Array, intersect(IntervalSet(1..5), IntervalSet(3..8)))
 1-element Vector{Interval{Int64, Closed, Closed}}:
  Interval{Int64, Closed, Closed}(3, 5)
  
-julia> Array(symdiff(IntervalSet(1..5), IntervalSet(3..8)))
+julia> convert(Array, symdiff(IntervalSet(1..5), IntervalSet(3..8)))
 2-element Vector{Interval{Int64}}:
  Interval{Int64, Closed, Open}(1, 3)
  Interval{Int64, Open, Closed}(5, 8)
 
-julia> Array(union(IntervalSet([1..2, 2..5]), IntervalSet(6..7)))
+julia> convert(Array, union(IntervalSet([1..2, 2..5]), IntervalSet(6..7)))
 2-element Vector{Interval{Int64, Closed, Closed}}:
  Interval{Int64, Closed, Closed}(1, 5)
  Interval{Int64, Closed, Closed}(6, 7)
 
-julia> Array(union(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
+julia> convert(Array, union(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
 2-element Vector{Interval{Int64, Closed, Closed}}:
  Interval{Int64, Closed, Closed}(1, 10)
  Interval{Int64, Closed, Closed}(12, 14)
 
-julia> Array(intersect(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
+julia> convert(Array, intersect(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
 2-element Vector{Interval{Int64, Closed, Closed}}:
  Interval{Int64, Closed, Closed}(4, 5)
  Interval{Int64, Closed, Closed}(8, 9)
 
-julia> Array(setdiff(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
+julia> convert(Array, setdiff(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
 2-element Vector{Interval{Int64}}:
  Interval{Int64, Closed, Open}(1, 4)
  Interval{Int64, Open, Closed}(9, 10)
@@ -64,7 +64,7 @@ Base.iterate(intervals::IntervalSet, args...) = iterate(intervals.items, args...
 Base.eltype(::IntervalSet{T}) where T = T
 Base.:(==)(a::IntervalSet, b::IntervalSet) = a.items == b.items
 Base.isequal(a::IntervalSet, b::IntervalSet) = isequal(a, b)
-Base.Array(intervals::IntervalSet) = intervals.items
+Base.convert(::Type{T}, intervals::IntervalSet) where T <: AbstractArray = convert(T, intervals.items)
 
 # currently (to avoid breaking changes) new methods for `Base`
 # accept `IntervalSet` objects and Interval singletons.

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -13,20 +13,21 @@ see also: https://en.wikipedia.org/wiki/Interval_arithmetic#Interval_operators
 ## Examples
 
 ```jldoctest
-julia> Array(union(IntervalSet([1..5]), IntervalSet[3..8]))
+julia> using Intervals
+julia> Array(union(IntervalSet(1..5), IntervalSet(3..8)))
 1-element Vector{Interval{Int64, Closed, Closed}}:
  Interval{Int64, Closed, Closed}(1, 8)
 
-julia> Array(intersect(IntervalSet([1..5]), IntervalSet([3..8])))
+julia> Array(intersect(IntervalSet(1..5), IntervalSet(3..8)))
 1-element Vector{Interval{Int64, Closed, Closed}}:
  Interval{Int64, Closed, Closed}(3, 5)
  
-julia> Array(symdiff(IntervalSet([1..5]), IntervalSet([3..8])))
+julia> Array(symdiff(IntervalSet(1..5), IntervalSet(3..8)))
 2-element Vector{Interval{Int64}}:
  Interval{Int64, Closed, Open}(1, 3)
  Interval{Int64, Open, Closed}(5, 8)
 
-julia> Array(union(IntervalSet([1..2, 2..5]), IntervalSet([6..7])))
+julia> Array(union(IntervalSet([1..2, 2..5]), IntervalSet(6..7)))
 2-element Vector{Interval{Int64, Closed, Closed}}:
  Interval{Int64, Closed, Closed}(1, 5)
  Interval{Int64, Closed, Closed}(6, 7)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -434,7 +434,7 @@ end
 Returns a `Vector{Vector{Int}}` where the value at index `i` gives the indices to all
 intervals in `y` that intersect with `x[i]`.
 """
-function find_intersections(x_::AbstractIntervals, y_::AbstractIntervals)
+function find_intersections(x_::Union{AbstractInterval, AbstractVector{<:AbstractInterval}}, y_::Union{AbstractInterval, AbstractVector{<:AbstractInterval}})
     xa, ya = vcat(x_), vcat(y_)
     tracking = endpoint_tracking(xa, ya)
     lt = intersection_isless_fn(tracking)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -5,8 +5,9 @@
     IntervalSet(x::AbstractVector{<:AbstractInterval})
 
 Interpret an array of intervals as a set of points: the union of all points in the
-intervals. Set operations over intervals sets will return an IntervalSet containing the
+intervals. Set operations over them will return an IntervalSet containing the
 fewest number of intervals that can be used to represent the resulting point set. 
+Unbounded intervals are not supported.
 
 ## Examples
 

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -14,25 +14,37 @@ see also: https://en.wikipedia.org/wiki/Interval_arithmetic#Interval_operators
 
 ```jldoctest; setup = :(using Intervals)
 julia> union(IntervalSet(1..5), IntervalSet(3..8))
+1-interval IntervalSet{Interval{Int64, Closed, Closed}}:
 [1 .. 8]
 
 julia> intersect(IntervalSet(1..5), IntervalSet(3..8))
+1-interval IntervalSet{Interval{Int64, Closed, Closed}}:
 [3 .. 5]
 
 julia> symdiff(IntervalSet(1..5), IntervalSet(3..8))
-[1 .. 3) ∪ (5 .. 8]
+2-interval IntervalSet{Interval{Int64}}:
+[1 .. 3)
+(5 .. 8]
 
 julia> union(IntervalSet([1..2, 2..5]), IntervalSet(6..7))
-[1 .. 5] ∪ [6 .. 7]
+2-interval IntervalSet{Interval{Int64, Closed, Closed}}:
+[1 .. 5]
+[6 .. 7]
 
 julia> union(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14]))
-[1 .. 10] ∪ [12 .. 14]
+2-interval IntervalSet{Interval{Int64, Closed, Closed}}:
+[1 .. 10]
+[12 .. 14]
 
 julia> intersect(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14]))
-[4 .. 5] ∪ [8 .. 9]
+2-interval IntervalSet{Interval{Int64, Closed, Closed}}:
+[4 .. 5]
+[8 .. 9]
 
 julia> setdiff(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14]))
-[1 .. 4) ∪ (9 .. 10]
+2-interval IntervalSet{Interval{Int64}}:
+[1 .. 4)
+(9 .. 10]
 ```
 """
 struct IntervalSet{T <: AbstractInterval}
@@ -54,11 +66,14 @@ Base.convert(::Type{T}, intervals::IntervalSet) where T <: AbstractArray = conve
 function Base.show(io::IO, ::MIME"text/plain", x::IntervalSet) 
     intervals = union(x)
     iocompact = IOContext(io, :compact => true)
+    print(io, "$(length(intervals))-interval ")
+    show(io, MIME"text/plain"(), typeof(x))
+    println(io, ":")
     for interval in intervals.items[1:(end-1)]
         show(iocompact, MIME"text/plain"(), interval)
-        print(io, " ∪ ")
+        println(io, "")
     end
-    show(iocompact, MIME"text/plain"(), intervals.items[end])
+    isempty(intervals) || show(iocompact, MIME"text/plain"(), intervals.items[end])
 end
 
 # currently (to avoid breaking changes) new methods for `Base`

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -1,7 +1,7 @@
 
 ###### Set-related Helpers #####
 """
-    IntervalSet{T<:AbstractInterval} <: AbstractSet{T}
+    IntervalSet{T<:AbstractInterval}
 
 An set of points represented by a sequence of intervals. Set operations over interval sets
 return a new IntervalSet, with the fewest number of intervals possible. Unbounded intervals
@@ -48,7 +48,7 @@ julia> Array(setdiff(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
  Interval{Int64, Open, Closed}(9, 10)
 ```
 """
-struct IntervalSet{A <: AbstractVector{<:AbstractInterval}}
+struct IntervalSet{I <: AbstractInterval, A <: AbstractVector{I}}
     items::A
 end
 
@@ -58,7 +58,7 @@ IntervalSet(interval::IntervalSet) = interval
 IntervalSet(itr) = IntervalSet{eltype(itr)}(collect(itr))
 IntervalSet() = IntervalSet{AbstractInterval}(AbstractInterval[])
 
-Base.copy(intervals::IntervalSet{T}) where T = IntervalSet{T}(copy(intervals.items))
+Base.copy(intervals::IntervalSet{T, A}) where {T, A} = IntervalSet{T, A}(copy(intervals.items))
 Base.length(intervals::IntervalSet) = length(intervals.items)
 Base.iterate(intervals::IntervalSet, args...) = iterate(intervals.items, args...)
 Base.eltype(::IntervalSet{T}) where T = T
@@ -110,8 +110,6 @@ end
 
 endpoint_tracking(a::IntervalSet, b::IntervalSet) = endpoint_tracking(eltype(a), eltype(b))
 endpoint_tracking(a::AbstractInterval, b::AbstractInterval) = endpoint_tracking(typeof(a), typeof(b))
-
-# TODO: Delete once union deprecation is gone.
 endpoint_tracking(a::AbstractVector, b::AbstractVector) = endpoint_tracking(eltype(a), eltype(b))
 
 # track: run a thunk, but only if we are tracking endpoints dynamically

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -68,9 +68,7 @@ Base.Array(intervals::IntervalSet) = intervals.items
 
 # currently (to avoid breaking changes) new methods for `Base`
 # accept `IntervalSet` objects and Interval singletons.
-const AbstractIntervalSets = Union{AbstractInterval, IntervalSet}
-# internal methods need to operate on both sets and arrays of intervals
-const AbstractIntervals = Union{AbstractIntervalSets, AbstractArray{<:AbstractInterval}}
+const AbstractIntervals = Union{AbstractInterval, IntervalSet}
 
 # During merge operations used to compute unions, intersections etc...,
 # endpoint types can change (from left to right, and from open to closed,
@@ -132,7 +130,8 @@ function unbunch(interval::AbstractInterval, tracking::EndpointTracking; lt=isle
     return endpoint_type(tracking)[LeftEndpoint(interval), RightEndpoint(interval)]
 end
 unbunch_by_fn(_) = identity
-function unbunch(intervals::Union{AbstractIntervals, Base.Iterators.Enumerate{<:AbstractIntervals}},
+function unbunch(intervals::Union{AbstractVector{<:AbstractInterval}, AbstractIntervals, 
+                                  Base.Iterators.Enumerate{<:AbstractIntervals}},
                  tracking::EndpointTracking; lt=isless)
     by = unbunch_by_fn(intervals)
     filtered = Iterators.filter(!isempty ∘ by, intervals)
@@ -147,7 +146,8 @@ function unbunch((i, interval)::Tuple, tracking; lt=isless)
     return eltype[(i, LeftEndpoint(interval)), (i, RightEndpoint(interval))]
 end
 
-function unbunch(a::AbstractIntervals, b::AbstractIntervals; kwargs...)
+function unbunch(a::Union{AbstractVector{<:AbstractInterval}, AbstractIntervals, 
+                 b::Union{AbstractVector{<:AbstractInterval}, AbstractIntervals}; kwargs...)
     tracking = endpoint_tracking(a, b)
     a_ = unbunch(a, tracking; kwargs...)
     b_ = unbunch(b, tracking; kwargs...)
@@ -424,8 +424,8 @@ end
 
 """
     find_intersections(
-        x::Union{AbstractInterval, IntervalSet},
-        y::Union{AbstractInterval, IntervalSet},
+        x::AbstractVector{<:AbstractInterval},
+        y::AbstractVector{<:AbstractInterval}
     )
 
 Returns a `Vector{Vector{Int}}` where the value at index `i` gives the indices to all

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -131,7 +131,8 @@ function unbunch(interval::AbstractInterval, tracking::EndpointTracking; lt=isle
 end
 unbunch_by_fn(_) = identity
 function unbunch(intervals::Union{AbstractVector{<:AbstractInterval}, AbstractIntervals, 
-                                  Base.Iterators.Enumerate{<:AbstractIntervals}},
+                                  Base.Iterators.Enumerate{<:Union{AbstractIntervals, 
+                                                                   AbstractVector{<:AbstractInterval}}}},
                  tracking::EndpointTracking; lt=isless)
     by = unbunch_by_fn(intervals)
     filtered = Iterators.filter(!isempty ∘ by, intervals)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -48,8 +48,8 @@ julia> Array(setdiff(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
  Interval{Int64, Open, Closed}(9, 10)
 ```
 """
-struct IntervalSet{T<:AbstractInterval}
-    items::Vector{<:AbstractInterval}
+struct IntervalSet{A <: AbstractVector{<:AbstractInterval}}
+    items::A
 end
 
 IntervalSet(v::AbstractVector) = IntervalSet{eltype(v)}(v)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -435,7 +435,7 @@ Returns a `Vector{Vector{Int}}` where the value at index `i` gives the indices t
 intervals in `y` that intersect with `x[i]`.
 """
 function find_intersections(x_::AbstractIntervals, y_::AbstractIntervals)
-    xa, ya = IntervalSet(x_), IntervalSet(y_)
+    xa, ya = vcat(x_), vcat(y_)
     tracking = endpoint_tracking(xa, ya)
     lt = intersection_isless_fn(tracking)
     x = unbunch(enumerate(xa), tracking; lt)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -5,7 +5,45 @@
     IntervalSet(x::AbstractVector{<:AbstractInterval})
 
 Interpret an array of intervals as a set of points: the union of all points in the
-intervals.
+intervals. Set operations over intervals sets will return an IntervalSet containing the
+fewest number of intervals that can be used to represent the resulting point set. 
+
+## Examples
+
+```jldoctest
+julia> Array(union(IntervalSet([1..5]), IntervalSet[3..8]))
+1-element Vector{Interval{Int64, Closed, Closed}}:
+ Interval{Int64, Closed, Closed}(1, 8)
+
+julia> Array(intersect(IntervalSet([1..5]), IntervalSet([3..8])))
+1-element Vector{Interval{Int64, Closed, Closed}}:
+ Interval{Int64, Closed, Closed}(3, 5)
+ 
+julia> Array(symdiff(IntervalSet([1..5]), IntervalSet([3..8])))
+2-element Vector{Interval{Int64}}:
+ Interval{Int64, Closed, Open}(1, 3)
+ Interval{Int64, Open, Closed}(5, 8)
+
+julia> Array(union(IntervalSet([1..2, 2..5]), IntervalSet([6..7])))
+2-element Vector{Interval{Int64, Closed, Closed}}:
+ Interval{Int64, Closed, Closed}(1, 5)
+ Interval{Int64, Closed, Closed}(6, 7)
+
+julia> Array(union(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
+2-element Vector{Interval{Int64, Closed, Closed}}:
+ Interval{Int64, Closed, Closed}(1, 10)
+ Interval{Int64, Closed, Closed}(12, 14)
+
+julia> Array(intersect(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
+2-element Vector{Interval{Int64, Closed, Closed}}:
+ Interval{Int64, Closed, Closed}(4, 5)
+ Interval{Int64, Closed, Closed}(8, 9)
+
+julia> Array(setdiff(IntervalSet([1..5, 8..10]), IntervalSet([4..9, 12..14])))
+2-element Vector{Interval{Int64}}:
+ Interval{Int64, Closed, Open}(1, 4)
+ Interval{Int64, Open, Closed}(9, 10)
+```
 """
 struct IntervalSet{T<:AbstractInterval}
     items::Vector{<:AbstractInterval}
@@ -22,6 +60,7 @@ Base.iterate(intervals::IntervalSet, args...) = iterate(intervals.items, args...
 Base.eltype(::IntervalSet{T}) where T = T
 Base.:(==)(a::IntervalSet, b::IntervalSet) = a.items == b.items
 Base.isequal(a::IntervalSet, b::IntervalSet) = isequal(a, b)
+Base.Array(intervals::IntervalSet) = intervals.items
 
 const AbstractIntervals = Union{AbstractInterval, IntervalSet}
 

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -52,11 +52,11 @@ struct IntervalSet{I <: AbstractInterval, A <: AbstractVector{I}}
     items::A
 end
 
-IntervalSet(v::AbstractVector) = IntervalSet{eltype(v)}(v)
-IntervalSet(interval::T) where T <: AbstractInterval = IntervalSet{T}([interval])
+IntervalSet{T}(intervals) where T <: AbstractInterval = IntervalSet{T, Vector{T}}(intervals)
+IntervalSet(interval::T) where T <: AbstractInterval = IntervalSet{T, Vector{T}}([interval])
 IntervalSet(interval::IntervalSet) = interval
 IntervalSet(itr) = IntervalSet{eltype(itr)}(collect(itr))
-IntervalSet() = IntervalSet{AbstractInterval}(AbstractInterval[])
+IntervalSet() = IntervalSet(AbstractInterval[])
 
 Base.copy(intervals::IntervalSet{T, A}) where {T, A} = IntervalSet{T, A}(copy(intervals.items))
 Base.length(intervals::IntervalSet) = length(intervals.items)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -36,9 +36,19 @@ end
 
     rand_bound_type(rng) = rand(rng, (Closed, Open))
 
-    # verify case where we interpret array as a set of intervals (rather than a set of
-    # points)
+    # verify case where we interpret array as a set of elements (rather than an
+    # interval-bound point set)
     @test intersect([1..2, 2..3, 3..4, 4..5], [2..3, 3..4]) == [2..3, 3..4]
+
+    # verify that elements are in / subsets of interval sets
+    @test 2 ∈ IntervalSet([1..3, 5..10])
+    @test 0 ∉ IntervalSet([1..3, 5..10])
+    @test 4 ∉ IntervalSet([1..3, 5..10])
+    @test 11 ∉ IntervalSet([1..3, 5..10])
+    @test issubset(2, IntervalSet([1..3, 5..10]))
+    @test !issubset(0, IntervalSet([1..3, 5..10]))
+    @test !issubset(4, IntervalSet([1..3, 5..10]))
+    @test !issubset(11, IntervalSet([1..3, 5..10]))
 
     function testsets(a, b)
         @test area(a ∪ b) ≤ area(myunion(a)) + area(myunion(b))

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -36,6 +36,10 @@ end
 
     rand_bound_type(rng) = rand(rng, (Closed, Open))
 
+    # verify case where we interpret array as a set of intervals (rather than a set of
+    # points)
+    @test intersect([1..2, 2..3, 3..4, 4..5], [2..3, 3..4]) == [2..3, 3..4]
+
     function testsets(a, b)
         @test area(a ∪ b) ≤ area(myunion(a)) + area(myunion(b))
         @test area(setdiff(a, b)) ≤ area(myunion(a))

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -50,7 +50,7 @@ end
         @test isdisjoint(setdiff(a, b), b)
         @test !isdisjoint(a, a)
 
-        intersections = find_intersections(Array(a), Array(b))
+        intersections = find_intersections(convert(Array, a), convert(Array, b))
 
         # verify that all indices returned in `find_intersections` correspond to sets
         # in b that overlap with the given set in a

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -50,7 +50,7 @@ end
         @test isdisjoint(setdiff(a, b), b)
         @test !isdisjoint(a, a)
 
-        intersections = find_intersections(a, b)
+        intersections = find_intersections(Array(a), Array(b))
 
         # verify that all indices returned in `find_intersections` correspond to sets
         # in b that overlap with the given set in a


### PR DESCRIPTION
This adds some documentation for `IntervalSets` and a test for the breaking behavior that lead  us to revert #175.

Also @omus, was there a reason you removed `find_intervals` from the docs? That's definitely one of the more useful functions I'm leveraging from the original PR. (I saw earlier that you remvoed it from the list of exports; not sure I understand that bit either but at the time didn't see a problem with an initial PR being that way, but I had missed that it was also removed from docs, so I'm wondering if you thought it was an implementation detail).

Another few notes:

- I've made it possible for `IntervalSet`'s field to be any `AbstractVector`. There are some cases where I have a view of `TimeSpan.jl` arrays that I want to be treated as `Interval.jl` arrays, I use an AbstractArray that converts the objects on the fly during `getindex`.
- I've removed the call to `IntervalSet` in `find_intersections`. This function really is operating on arrays of intervals: it computes intersections between individual intervals and reports on which intervals in `y` intersect with intervals in `x`. No merging or re-ordering of the intervals should ever happen.