### PR TITLE
Correct set documentation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,7 +35,7 @@ used to represent a disjoint set. For general purpose set operations you need to
 IntervalSet
 ```
 
-If you wish to instead treat each interval as an *element* of a set, you can operate over vectors or Sets of intervals.
+If you wish to instead treat each interval as an *element* of a set, you can operate over vectors or `Set`s of intervals.
 
 For example:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,7 +29,7 @@ This package defines:
 ## Sets
 
 A single interval can be used to represent a contiguous set within a domain but cannot be
-used to represent a disjoint set. For general purpose set operations you need to use the `InteravlSet` type.
+used to represent a disjoint set. For general purpose set operations you need to use the `IntervalSet` type.
 
 ```@docs
 IntervalSet

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,31 +29,21 @@ This package defines:
 ## Sets
 
 A single interval can be used to represent a contiguous set within a domain but cannot be
-used to represent a disjoint set. Due to this restriction all set-based operations that
-return an interval will always return a vector of intervals. These operations will combine
-any intervals which are overlapping or touching into a single continuous interval and never
-return an interval instance which itself is empty.
+used to represent a disjoint set. For general purpose set operations you need to use the `InteravlSet` type, which allows for generic set-based operations over intervals.
+
+```@docs
+IntervalSet
+```
+
+If you wish to instead treat each interval as an *element* of a set, you can operate over vectors or Sets of intervals.
+
+For example:
 
 ```julia
-julia> union([1..10], [5..15])
-1-element Vector{Interval{Int64, Closed, Closed}}:
- Interval{Int64, Closed, Closed}(1, 15)
-
-julia> intersect([1..10], [5..15])
-1-element Vector{Interval{Int64, Closed, Closed}}:
- Interval{Int64, Closed, Closed}(5, 10)
-
-julia> setdiff([1..10], [5..15])
-1-element Vector{Interval{Int64, Closed, Open}}:
- Interval{Int64, Closed, Open}(1, 5)
-
-julia> symdiff([1..10], [5..15])
-2-element Vector{Interval{Int64}}:
- Interval{Int64, Closed, Open}(1, 5)
- Interval{Int64, Open, Closed}(10, 15)
-
-julia> intersect([1..5], [10..15])
-Interval[]
+julia> intersect([1..2, 2..3, 3..4, 4..5], [2..3, 3..4])
+2-element Vector{Interval{Int64, Closed, Closed}}:
+ Interval{Int64, Closed, Closed}(2, 3)
+ Interval{Int64, Closed, Closed}(3, 4)
 ```
 
 ## Example Usage

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -258,7 +258,6 @@ In the plot, inclusive boundaries are marked with a vertical bar, whereas exclus
 ```@docs
 Interval
 AnchoredInterval
-IntervalSet
 HourEnding
 HourBeginning
 HE

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,7 +29,7 @@ This package defines:
 ## Sets
 
 A single interval can be used to represent a contiguous set within a domain but cannot be
-used to represent a disjoint set. For general purpose set operations you need to use the `InteravlSet` type, which allows for generic set-based operations over intervals.
+used to represent a disjoint set. For general purpose set operations you need to use the `InteravlSet` type.
 
 ```@docs
 IntervalSet

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -5,8 +5,8 @@
 
 A set of points represented by a sequence of intervals. Set operations over interval sets
 return a new IntervalSet, with the fewest number of intervals possible. Unbounded intervals
-are not supported. The individual intervals in the set can be accessed using the iteration
-API or by passing the set to `Array`.
+are not supported. The individual intervals in the set can be accessed by calling
+`convert(Array, interval_set)`.
 
 see also: https://en.wikipedia.org/wiki/Interval_arithmetic#Interval_operators
 


### PR DESCRIPTION
Found this error in the documentation. The documentation refers to the original design, implemented in #179 rather than the final design, as implemented in #196.