### PR TITLE
Handle empty-interval edge case in `find_intersections`

### DIFF
--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -471,11 +471,12 @@ end
 """
     find_intersections(x, y)
 
-Returns a `Vector{Vector{Int}}` where the value at index `i` gives the indices to all
-intervals in `y` that intersect with `x[i]`. Calls collect on the arguments if they
-aren't already arrays.
+Find the intervals in `y` that intersect with intervals in `x`. Returns a vector, `z`, where
+each element `z[i]` is a vector of all indices in `y` that intersect with `x[i]`. The values
+`x` and `y` should be iterables of intervals. 
 """
 find_intersections(x, y) = find_intersections_(collect(x), collect(y))
+find_intersections(x::AbstractVector, y::Abstractvector) = find_intersections_(x, y)
 function find_intersections_(x::AbstractVector, y::AbstractVector)
     (isempty(x) || isempty(y)) && return Vector{Int}[]
     tracking = endpoint_tracking(x, y)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -476,7 +476,7 @@ intervals in `y` that intersect with `x[i]`. Calls collect on the arguments if t
 aren't already arrays.
 """
 find_intersections(x, y) = find_intersections_(collect(x), collect(y))
-function find_intersections_(x::AbstractVector{<:AbstractInterval}, y::AbstractVector{<:AbstractInterval})
+function find_intersections_(x::AbstractVector, y::AbstractVector)
     (isempty(x) || isempty(y)) && return Vector{Int}[]
     tracking = endpoint_tracking(x, y)
     lt = intersection_isless_fn(tracking)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -469,22 +469,13 @@ function intersection_isless_fn(::TrackEachEndpoint)
 end
 
 """
-    find_intersections(
-        x::AbstractVector{<:AbstractInterval},
-        y::AbstractVector{<:AbstractInterval}
-    )
+    find_intersections(x, y)
 
 Returns a `Vector{Vector{Int}}` where the value at index `i` gives the indices to all
-intervals in `y` that intersect with `x[i]`.
+intervals in `y` that intersect with `x[i]`. Calls collect on the arguments if they
+aren't already arrays.
 """
-find_intersections(x, y) = find_intersections_(vcat(x), vcat(y))
-function find_intersections_(x, y)
-    if isempty(x) && isempty(y)
-        return Vector{Int}[]
-    else
-        throw(ArgumentError("Expected arrays of `AbstractInterval` objects"))
-    end
-end
+find_intersections(x, y) = find_intersections_(collect(x), collect(y))
 function find_intersections_(x::AbstractVector{<:AbstractInterval}, y::AbstractVector{<:AbstractInterval})
     (isempty(x) || isempty(y)) && return Vector{Int}[]
     tracking = endpoint_tracking(x, y)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -471,9 +471,9 @@ end
 """
     find_intersections(x, y)
 
-Find the intervals in `y` that intersect with intervals in `x`. Returns a vector, `z`, where
-each element `z[i]` is a vector of all indices in `y` that intersect with `x[i]`. The values
-`x` and `y` should be iterables of intervals. 
+For each interval in `x` find all intervals in `y` that it intersects with. Returns a
+vector, `z`, where each element `z[i]` is a vector of all indices in `y` that intersect with
+`x[i]`. The values `x` and `y` should be iterables of intervals. 
 """
 find_intersections(x, y) = find_intersections_(collect(x), collect(y))
 find_intersections(x::AbstractVector, y::AbstractVector) = find_intersections_(x, y)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -477,8 +477,16 @@ end
 Returns a `Vector{Vector{Int}}` where the value at index `i` gives the indices to all
 intervals in `y` that intersect with `x[i]`.
 """
-find_intersections(x, y) = find_intersections(vcat(x), vcat(y))
-function find_intersections(x::AbstractVector{<:AbstractInterval}, y::AbstractVector{<:AbstractInterval})
+find_intersections(x, y) = find_intersections_(vcat(x), vcat(y))
+function find_intersections_(x, y)
+    if isempty(x) && isempty(y)
+        return Vector{Int}[]
+    else
+        throw(ArgumentError("Expected arrays of `AbstractInterval` objects"))
+    end
+end
+function find_intersections_(x::AbstractVector{<:AbstractInterval}, y::AbstractVector{<:AbstractInterval})
+    (isempty(x) || isempty(y)) && return Vector{Int}[]
     tracking = endpoint_tracking(x, y)
     lt = intersection_isless_fn(tracking)
     x_endpoints = unbunch(enumerate(x), tracking; lt)

--- a/src/interval_sets.jl
+++ b/src/interval_sets.jl
@@ -476,7 +476,7 @@ each element `z[i]` is a vector of all indices in `y` that intersect with `x[i]`
 `x` and `y` should be iterables of intervals. 
 """
 find_intersections(x, y) = find_intersections_(collect(x), collect(y))
-find_intersections(x::AbstractVector, y::Abstractvector) = find_intersections_(x, y)
+find_intersections(x::AbstractVector, y::AbstractVector) = find_intersections_(x, y)
 function find_intersections_(x::AbstractVector, y::AbstractVector)
     (isempty(x) || isempty(y)) && return Vector{Int}[]
     tracking = endpoint_tracking(x, y)

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -581,8 +581,7 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
         @testset "StepRangeLen" begin
             r = StepRangeLen(AnchoredInterval{-1}(1), 1, 5)
 
-            # https://github.com/JuliaLang/julia/issues/33882
-            @test r isa (VERSION < v"1.8" ? StepRangeLen : StepRange)
+            @test r isa StepRangeLen
             @test first(r) == AnchoredInterval{-1}(1)
             @test step(r) == 1
             @test last(r) == AnchoredInterval{-1}(5)

--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -582,7 +582,7 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
             r = StepRangeLen(AnchoredInterval{-1}(1), 1, 5)
 
             # https://github.com/JuliaLang/julia/issues/33882
-            @test r isa StepRangeLen
+            @test r isa (VERSION < v"1.8" ? StepRangeLen : StepRange)
             @test first(r) == AnchoredInterval{-1}(1)
             @test step(r) == 1
             @test last(r) == AnchoredInterval{-1}(5)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -51,6 +51,12 @@ end
     @test !issubset(11, IntervalSet([1..3, 5..10]))
     @test issubset(2, IntervalSet([1.0 .. 3.0, 5.0 .. 10.0]))
 
+    @test isempty(find_intersections([], []))
+    @test_throws ArgumnetError find_intersections([1], [2])
+    @test isempty(find_intersections(Interval[], Interval[]))
+    @test isempty(find_intersections([1..3], Interval[]))
+    @test isempty(find_intersections(Interval[], [1..3]))
+
     function testsets(a, b)
         @test area(a ∪ b) ≤ area(myunion(a)) + area(myunion(b))
         @test area(setdiff(a, b)) ≤ area(myunion(a))

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -54,8 +54,8 @@ end
     @test isempty(find_intersections([], []))
     @test_throws MethodError find_intersections([1], [2])
     @test isempty(find_intersections(Interval[], Interval[]))
-    @test isempty(find_intersections([1..3], Interval[]))
-    @test isempty(find_intersections(Interval[], [1..3]))
+    @test isempty(find_intersections([1..3], []))
+    @test isempty(find_intersections([], [1..3]))
 
     function testsets(a, b)
         @test area(a ∪ b) ≤ area(myunion(a)) + area(myunion(b))

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -52,7 +52,7 @@ end
     @test issubset(2, IntervalSet([1.0 .. 3.0, 5.0 .. 10.0]))
 
     @test isempty(find_intersections([], []))
-    @test_throws ArgumnetError find_intersections([1], [2])
+    @test_throws ArgumentError find_intersections([1], [2])
     @test isempty(find_intersections(Interval[], Interval[]))
     @test isempty(find_intersections([1..3], Interval[]))
     @test isempty(find_intersections(Interval[], [1..3]))

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -52,7 +52,7 @@ end
     @test issubset(2, IntervalSet([1.0 .. 3.0, 5.0 .. 10.0]))
 
     @test isempty(find_intersections([], []))
-    @test_throws ArgumentError find_intersections([1], [2])
+    @test_throws MethodError find_intersections([1], [2])
     @test isempty(find_intersections(Interval[], Interval[]))
     @test isempty(find_intersections([1..3], Interval[]))
     @test isempty(find_intersections(Interval[], [1..3]))

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -51,11 +51,14 @@ end
     @test !issubset(11, IntervalSet([1..3, 5..10]))
     @test issubset(2, IntervalSet([1.0 .. 3.0, 5.0 .. 10.0]))
 
+    # verify the various input types `find_intersections` can handle
     @test isempty(find_intersections([], []))
     @test_throws MethodError find_intersections([1], [2])
     @test isempty(find_intersections(Interval[], Interval[]))
     @test isempty(find_intersections([1..3], []))
     @test isempty(find_intersections([], [1..3]))
+    @test !isempty(find_intersections([1..2, 3..4], 
+                                      AnchoredInterval{-1}(1):1:AnchoredInterval{-1}(5)))
 
     function testsets(a, b)
         @test area(a ∪ b) ≤ area(myunion(a)) + area(myunion(b))


### PR DESCRIPTION
Closes #200 

Title says it all. This fix also will address some edge cases where `find_intersections` would throw a StackOverflowError when passed an incorrect type.

Small aside: When I ran tests locally there was a failure on 1.8 (had to run on 1.7). Looks to be related to a now closed issue in 1.8.