### PR TITLE
Fix `StepRangeLen` test

### DIFF
--- a/test/anchoredinterval.jl
+++ b/test/anchoredinterval.jl
@@ -579,14 +579,14 @@ using Intervals: Bounded, Ending, Beginning, canonicalize, isunbounded
         end
 
         @testset "StepRangeLen" begin
-            r = AnchoredInterval{-1}(1):1:AnchoredInterval{-1}(5)
-            r = r[1:5]
+            r = StepRangeLen(AnchoredInterval{-1}(1), 1, 5)
 
             # https://github.com/JuliaLang/julia/issues/33882
             @test r isa StepRangeLen
             @test first(r) == AnchoredInterval{-1}(1)
             @test step(r) == 1
             @test last(r) == AnchoredInterval{-1}(5)
+            @test r == AnchoredInterval{-1}(1):1:AnchoredInterval{-1}(5)
         end
 
         @testset "hourly, implicit" begin


### PR DESCRIPTION
Explicitly create a `StepRangeLen` for these tests instead of relying on `getindex` to return a `StepRangeLen`. This behaviour was changed in https://github.com/JuliaLang/julia/pull/43059