### PR TITLE
Generic Interval Interface

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,6 +26,9 @@ This package defines:
   * [`Open`](@ref), indicating the endpoint value of the interval is not included
   * [`Unbounded`](@ref), indicating the endpoint value is effectively infinite
 
+You can create your own `AbstractInterval` type by following the interface specification
+provided below.
+
 ## Sets
 
 A single interval can be used to represent a contiguous set within a domain but cannot be
@@ -262,6 +265,26 @@ julia> plot(intervals, 1:11)
 
 In the plot, inclusive boundaries are marked with a vertical bar, whereas exclusive boundaries just end.
 
+## Interval Interface
+
+To create your own `AbstractInterval` type you need to define how to get the lower and upper
+bound of the interval and how to construct new intervals of your type from these bounds.
+All other functions defined in this package should work correctly if you do this.
+
+Construction of new intervals requires knowing how to intervals types interact: e.g. if you compute the intersection of two intervals, one that's of your new interval type and one that's an Interval, what should be returned? The default factory always constructs `Interval` objects regardless of the input types. To define a different behavior, you create an `Interval.AbstractFactory` subtype.
+
+```@docs
+Intervals.AbstractFactory
+Intervals.factory
+Intervals.interval_type
+```
+
+To define how to get the lower and upper bound of your type, define a method for `Intervals.LowerBound` and `Intervals.UpperBound`; these are intended to be constructors and are expected to return objects of their respective type.
+
+```@docs
+Intervals.UpperBound(::AbstractInterval, ::Intervals.AbstractFactory)
+Intervals.LowerBound(::AbstractInterval, ::Intervals.AbstractFactory)
+```
 
 ## API
 

--- a/src/endpoint.jl
+++ b/src/endpoint.jl
@@ -33,8 +33,10 @@ const RightEndpoint{T,B} = Endpoint{T, Right, B} where {T,B <: Bound}
 LeftEndpoint{B}(ep::T) where {T,B} = LeftEndpoint{T,B}(ep)
 RightEndpoint{B}(ep::T) where {T,B} = RightEndpoint{T,B}(ep)
 
-LeftEndpoint(i::AbstractInterval{T,L,R}) where {T,L,R} = LeftEndpoint{T,L}(L !== Unbounded ? first(i) : nothing)
-RightEndpoint(i::AbstractInterval{T,L,R}) where {T,L,R} = RightEndpoint{T,R}(R !== Unbounded ? last(i) : nothing)
+LeftEndpoint(i::AbstractInterval) = LeftEndpoint(i, interval_factory(i))
+RightEndpoint(i::AbstractInterval) = RightEndpoint(i, interval_factory(i))
+LeftEndpoint(i::AbstractInterval{T,L,R}, ::DefaultFactory) where {T,L,R} = LeftEndpoint{T,L}(L !== Unbounded ? first(i) : nothing)
+RightEndpoint(i::AbstractInterval{T,L,R}, ::DefaultFactory) where {T,L,R} = RightEndpoint{T,R}(R !== Unbounded ? last(i) : nothing)
 
 endpoint(x::Endpoint) = isbounded(x) ? x.endpoint : nothing
 bound_type(x::Endpoint{T,D,B}) where {T,D,B} = B

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -389,30 +389,24 @@ function contiguous(a::AbstractInterval, b::AbstractInterval)
     )
 end
 
-function Base.intersect(a::AbstractInterval{T}, b::AbstractInterval{T}) where T
-    !overlaps(a,b) && return Interval{T}()
+function Base.intersect(a::AbstractInterval, b::AbstractInterval)
+    tracking = endpoint_tracking(a, b)
+    !overlaps(a,b) && return tointerval(tracking)
     left = max(LeftEndpoint(a), LeftEndpoint(b))
     right = min(RightEndpoint(a), RightEndpoint(b))
 
-    return Interval{T}(left, right)
-end
-
-function Base.intersect(a::AbstractInterval{S}, b::AbstractInterval{T}) where {S,T}
-    !overlaps(a, b) && return Interval{promote_type(S, T)}()
-    left = max(LeftEndpoint(a), LeftEndpoint(b))
-    right = min(RightEndpoint(a), RightEndpoint(b))
-
-    return Interval(left, right)
+    return tointerval(left, right, tracking)
 end
 
 function Base.merge(a::AbstractInterval, b::AbstractInterval)
+    tracking = endpoint_tracking(a, b)
     if !overlaps(a, b) && !contiguous(a, b)
         throw(ArgumentError("$a and $b are neither overlapping or contiguous."))
     end
 
     left = min(LeftEndpoint(a), LeftEndpoint(b))
     right = max(RightEndpoint(a), RightEndpoint(b))
-    return Interval(left, right)
+    return tointerval(left, right, tracking)
 end
 
 ##### ROUNDING #####

--- a/src/interval.jl
+++ b/src/interval.jl
@@ -392,10 +392,10 @@ end
 function Base.intersect(a::AbstractInterval, b::AbstractInterval)
     tracking = endpoint_tracking(a, b)
     !overlaps(a,b) && return tointerval(tracking)
-    left = max(LeftEndpoint(a), LeftEndpoint(b))
-    right = min(RightEndpoint(a), RightEndpoint(b))
+    left = max(LeftEndpoint(a, tracking), LeftEndpoint(b, tracking))
+    right = min(RightEndpoint(a, tracking), RightEndpoint(b, tracking))
 
-    return tointerval(left, right, tracking)
+    return tracking(left, right)
 end
 
 function Base.merge(a::AbstractInterval, b::AbstractInterval)
@@ -404,9 +404,9 @@ function Base.merge(a::AbstractInterval, b::AbstractInterval)
         throw(ArgumentError("$a and $b are neither overlapping or contiguous."))
     end
 
-    left = min(LeftEndpoint(a), LeftEndpoint(b))
-    right = max(RightEndpoint(a), RightEndpoint(b))
-    return tointerval(left, right, tracking)
+    left = min(LeftEndpoint(a, tracking), LeftEndpoint(b, tracking))
+    right = max(RightEndpoint(a, tracking), RightEndpoint(b, tracking))
+    return tracking(left, right)
 end
 
 ##### ROUNDING #####

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -40,6 +40,24 @@ end
     # interval-bound point set)
     @test intersect([1..2, 2..3, 3..4, 4..5], [2..3, 3..4]) == [2..3, 3..4]
 
+    # verify that the internal representation of type stable interval sets
+    # makes use of union splitting
+    @test ==(eltype(Intervals.unbunch([Interval{Open,Open}(1, 2), 
+                    Interval{Open,Open}(3,4)])),
+             Union{Intervals.LeftEndpoint{Int, Open}, Intervals.RightEndpoint{Int, Open}})
+    @test ==(eltype(Intervals.unbunch([Interval{Closed,Closed}(1, 2), 
+                    Interval{Closed,Closed}(3,4)])),
+             Union{Intervals.LeftEndpoint{Int, Closed}, Intervals.RightEndpoint{Int, Closed}})
+    @test ==(eltype(Intervals.unbunch([Interval{Open,Closed}(1, 2), 
+                    Interval{Open,Closed}(3,4)])),
+             Union{Intervals.LeftEndpoint{Int, Open}, Intervals.RightEndpoint{Int, Closed}})
+    @test ==(eltype(Intervals.unbunch([Interval{Closed,Open}(1, 2), 
+                    Interval{Closed,Open}(3,4)])),
+             Union{Intervals.LeftEndpoint{Int, Closed}, Intervals.RightEndpoint{Int, Open}})
+    @test ==(eltype(Intervals.unbunch([Interval{Closed,Open}(1, 2), 
+                    Interval{Open,Closed}(3,4)])), 
+             Intervals.Endpoint{Int})
+
     # verify that elements are in / subsets of interval sets
     @test 2 ∈ IntervalSet([1..3, 5..10])
     @test 0 ∉ IntervalSet([1..3, 5..10])


### PR DESCRIPTION
This is an old branch, sketching out a possible way to make the `Intervals` interface extensible. It would allow, e.g. `TimeSpans` or `AlignedSpans` to be an `AbstractInterval`.