### PR TITLE
Update plotting recipe to support Plots 1.10.0

### DIFF
--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -3,26 +3,31 @@ interval_markers(L::Type{<:Bound}, R::Type{<:Bound}) = interval_marker.([L, R])
 interval_marker(x::Type{Closed}) = :vline
 interval_marker(x::Type{Open}) = :none
 
+_alpha(marker::Symbol) = marker === :none ? 0 : 1
+
 # TODO: Add support for plotting unbounded intervals
 @recipe function f(xs::AbstractVector{<:AbstractInterval{T,L,R}}, ys) where {T, L <: Bounded, R <: Bounded}
-    new_xs = T[]
+    new_xs = Vector{T}[]
     new_ys = []
-    markers = Symbol[]
+    markers = Vector{Symbol}[]
     for (x, y) in zip(xs, ys)
+        marker = interval_markers(x)
+
         # To cause line to not be connected, need to add a breaker point with
         # NaN in one of the coordinates. We put that in `new_ys` as that is probably a
         # float. where-as new_xs is potentially a DateTime etc that would not accept NaN
-        append!(new_xs, [first(x), last(x), last(x)])
-        append!(new_ys, [y, y, NaN])
-        append!(markers, interval_markers(x))
-        push!(markers, :none)
+        push!(new_xs, [first(x), last(x)])
+        push!(new_ys, [y, y])
+        push!(markers, interval_markers(x))
     end
 
-    # Work around GR bug that shows :none as a marker
-    # TODO: remove once https://github.com/jheinen/GR.jl/issues/295  is fixed
-    markeralpha := [x == :none ? 0 : 1 for x in markers]
+    # Work around GR bug that shows `:none` as a marker
+    # TODO: remove once https://github.com/jheinen/GR.jl/issues/295 is fixed
+    markeralpha := permutedims([_alpha.(m) for m in markers])
 
     markershape := markers
-    seriestype  := :path  # always a path, even in a scatter plot
-    new_xs, new_ys
+    seriestype  := :path                 # always a path, even in a scatter plot
+    markershape := permutedims(markers)  # force markershape to be set the endpoints
+
+    return new_xs, new_ys
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,4 +17,5 @@ VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
 [compat]
 Documenter = "0.23, 0.24, 0.25, 0.26, 0.27"
 Infinity = "0.2.3"
+Plots = "1.10.0"
 UTCDateTimes = "1.1"


### PR DESCRIPTION
Attempts to eliminate the plotting warnings we see during testing:
```julia
┌ Warning: Indices Base.OneTo(33) of attribute `markeralpha` does not match data indices 1:32.
└ @ Plots ~/.julia/packages/Plots/rz1WP/src/utils.jl:141
┌ Info: Data contains NaNs or missing values, and indices of `markeralpha` vector do not match data indices.
│ If you intend elements of `markeralpha` to apply to individual NaN-separated segments in the data,
│ pass each segment in a separate vector instead, and use a row vector for `markeralpha`. Legend entries
│ may be suppressed by passing an empty label.
│ For example,
└     plot([1:2,1:3], [[4,5],[3,4,5]], label=["y" ""], markeralpha=[1 2])
```
This [PR](https://github.com/JuliaPlots/Plots.jl/pull/3320) is responsible for the above warning.

A quick example that generates the warnings is:
```julia
plot([1, 3, NaN, 2, 5, NaN], [1, 1, NaN, 2, 2, NaN], markershape=[:vline, :vline, :none, :vline, :none, :none], markeralpha=[1, 1, 0, 1, 0, 0])
```
and the equivalent plot without the warnings:
```julia
plot([[1, 3], [2, 5]], [[1, 1], [2, 2]], markershape=permutedims([[:vline, :vline], [:vline, :none]]), markeralpha=permutedims([[1, 1], [1, 0]]))
```

Unfortunately, this approach doesn't work for `TimeType`s so I've reported this as an issue against Plots: 

- https://github.com/JuliaPlots/Plots.jl/issues/4777